### PR TITLE
FA-416 Added OAuthAction

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -59,6 +59,16 @@
           "apiKey": ""
         }
       }
+    },
+    "oauth": {
+      "github": {
+        "clientId": "",
+        "clientSecret": ""
+      },
+      "facebook": {
+        "clientId": "",
+        "clientSecret": ""
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lodash": "^2.4.1",
     "lodash.camelcase": "^3.0.1",
     "lodash.deburr": "^3.0.2",
+    "lodash.has": "^3.2.1",
     "lodash.property": "^3.1.2",
     "lodash.pull": "^3.0.1",
     "method-override": "^2.3.0",

--- a/src/actions/AuthAction.js
+++ b/src/actions/AuthAction.js
@@ -144,6 +144,10 @@ module.exports = function(router) {
    *   The callback function to execute upon completion.
    */
   AuthAction.prototype.resolve = function(handler, method, req, res, next) {
+    if (req.submission && req.submission.hasOwnProperty('oauth')) {
+      return next(); // OAuth Action will handle authentication
+    }
+
     if (!req.submission || !req.submission.hasOwnProperty('data')) {
       return next('Submission data is required to Authenticate.');
     }

--- a/src/actions/DefaultAction.js
+++ b/src/actions/DefaultAction.js
@@ -52,7 +52,7 @@ module.exports = function(router) {
     var initiallyEmpty = (req.body.data && Object.keys(req.body.data).length === 0);
 
     // Establish our resource data array.
-    var resourceData = {};
+    var resourceData = _.assign({}, req.resourceData); // For actions that set resource data like oauth
     var submissionData = {};
 
     // Iterate through all of our data in the request.

--- a/src/actions/OAuthAction.js
+++ b/src/actions/OAuthAction.js
@@ -1,0 +1,521 @@
+'use strict';
+
+var Action = require('./Action');
+var util = require('../util/util');
+var debug = require('debug')('formio:action:oauth');
+var _ = require('lodash');
+var crypto = require('crypto');
+var mongoose = require('mongoose');
+var Q = require('q');
+
+
+module.exports = function(router) {
+  var hook = require('../util/hook')(router.formio);
+  var oauthUtil = require('../util/oauth')(router.formio);
+
+  /**
+   * OAuthAction class.
+   *   This class is used to create the OAuth action.
+   *
+   * @constructor
+   */
+  var OAuthAction = function(data, req, res) {
+    Action.call(this, data, req, res);
+
+    // Disable the default action if the association is existing.
+    req.disableDefaultAction = (data.settings.association === 'existing');
+  };
+
+  // Derive from Action.
+  OAuthAction.prototype = Object.create(Action.prototype);
+  OAuthAction.prototype.constructor = OAuthAction;
+  OAuthAction.info = function(req, res, next) {
+    next(null, {
+      name: 'oauth',
+      title: 'OAuth',
+      description: 'Provides OAuth authentication behavior to this form.',
+      priority: 20,
+      defaults: {
+        handler: ['after', 'before'],
+        method: ['form', 'create']
+      }
+    });
+  };
+  // Disable editing handler and method settings
+  OAuthAction.access = {
+    handler: false,
+    method: false
+  };
+
+  /**
+   * Settings form for auth action.
+   *
+   * @param req
+   * @param res
+   * @param next
+   */
+  OAuthAction.settingsForm = function(req, res, next) {
+    var fieldsSrc = hook.alter('url', '/form/' + req.params.formId + '/components', req);
+    var resourceSrc = hook.alter('url', '/form?type=resource', req);
+    router.formio.roles.resource.model.find(hook.alter('roleQuery', {}, req))
+      .sort({title: 1})
+      .exec(function(err, roles) {
+        if (err || !roles) {
+          return res.status(400).send('Could not load the Roles.');
+        }
+        Q.all([
+          oauthUtil.availableProviders(req),
+          Q.ninvoke(router.formio.cache, 'loadCurrentForm', req)
+        ])
+        .then(function(results) {
+          var availableProviders = results[0];
+          var form = results[1];
+          next(null, [
+            {
+              type: 'select',
+              input: true,
+              label: 'OAuth Provider',
+              key: 'settings[provider]',
+              placeholder: 'Select the OAuth Provider',
+              template: '<span>{{ item.title }}</span>',
+              dataSrc: 'json',
+              data: {
+                json: JSON.stringify(availableProviders)
+              },
+              valueProperty: 'name',
+              multiple: false,
+              validate: {
+                required: true
+              }
+            },
+            {
+              type: 'select',
+              input: true,
+              label: 'Action',
+              key: 'settings[association]',
+              placeholder: 'Select the action to perform',
+              template: '<span>{{ item.title }}</span>',
+              dataSrc: 'json',
+              data: {
+                json: JSON.stringify([
+                  {
+                    association: 'existing',
+                    title: 'Login Existing Resource'
+                  },
+                  {
+                    association: 'new',
+                    title: 'Register New Resource'
+                  },
+                  {
+                    association: 'link',
+                    title: 'Link Current User'
+                  }
+                ])
+              },
+              valueProperty: 'association',
+              multiple: false,
+              validate: {
+                required: true
+              }
+            },
+            {
+              type: 'select',
+              input: true,
+              label: 'Resource',
+              key: 'settings[resource]',
+              placeholder: 'Select the Resource to authenticate against',
+              template: '<span>{{ item.title }}</span>',
+              dataSrc: 'url',
+              data: {url: resourceSrc},
+              valueProperty: '_id',
+              multiple: false,
+              validate: {
+                required: true
+              }
+            },
+            {
+              type: 'select',
+              input: true,
+              label: 'Role',
+              key: 'settings[role]',
+              placeholder: 'Select the Role that will be added to new Resources',
+              template: '<span>{{ item.title }}</span>',
+              dataSrc: 'json',
+              data: {json: roles},
+              valueProperty: '_id',
+              multiple: false
+            },
+            {
+              type: 'select',
+              input: true,
+              label: 'Sign-in with OAuth Button',
+              key: 'settings[button]',
+              placeholder: 'Select the button that triggers OAuth sign-in',
+              template: '<span>{{ item.label || item.key }}</span>',
+              dataSrc: 'json',
+              data: {
+                json: JSON.stringify(_.filter(form.components, {type: 'button', action: 'oauth'}))
+              },
+              valueProperty: 'key',
+              multiple: false,
+              validate: {
+                required: true
+              }
+            }
+          ]
+          .concat(
+            _(router.formio.oauth.providers)
+            .map(function(provider) {
+              return _.map(provider.autofillFields, function(field) {
+                return {
+                  type: 'select',
+                  input: true,
+                  label: 'Autofill ' + field.title + ' Field',
+                  key: 'settings[autofill-' + provider.name + '-' + field.name + ']',
+                  placeholder: 'Select which field to autofill with ' + provider.title + ' account ' + field.title,
+                  template: '<span>{{ item.label || item.key }}</span>',
+                  dataSrc: 'url',
+                  data: {url: fieldsSrc},
+                  valueProperty: 'key',
+                  multiple: false
+                };
+              });
+            })
+            .flatten()
+            .value()
+          ));
+        })
+        .catch(next);
+      });
+  };
+
+  OAuthAction.prototype.authenticate = function(req, res, provider, accessToken) {
+    debug('Authenticating with Access Token:', accessToken);
+
+    var userInfo = null, userId = null, resource = null;
+    var self = this;
+
+    return Q.all([
+      provider.getUser(accessToken),
+      Q.denodeify(router.formio.cache.loadForm.bind(router.formio.cache))(req, 'resource', self.settings.resource)
+    ])
+    .then(function(results) {
+      userInfo = results[0];
+      userId = provider.getUserId(userInfo);
+      resource = results[1];
+
+      debug('userInfo:', userInfo);
+      debug('userId:', userId);
+
+      return router.formio.auth.authenticateOAuth(resource, provider.name, userId);
+    })
+    .then(function(result) {
+      if (result) { // Authenticated existing resource
+        req.user = result.user;
+        req.token = result.token.decoded;
+        res.token = result.token.token;
+        req['x-jwt-token'] = result.token.token;
+
+        // Manually invoke router.formio.auth.currentUser to trigger resourcejs middleware.
+        return Q.nfcall(router.formio.auth.currentUser, req, res);
+      }
+      else { // Need to create and auth new resource
+        // If we were looking for an existing resource, return an error
+        if (self.settings.association === 'existing') {
+          throw {
+            status: '404',
+            message: provider.title + ' account has not yet been linked.'
+          };
+        }
+        // Add some default resourceData so DefaultAction creates the resource
+        // even with empty submission data
+        req.resourceData = req.resourceData || {};
+        req.resourceData[resource.name] = {data: {}};
+
+        // Find and fill in all the autofill fields
+        var regex = new RegExp('autofill-' + provider.name + '-(.+)');
+        _.each(self.settings, function(value, key) {
+          var match = key.match(regex);
+          if (match && value && userInfo[match[1]]) {
+            req.body.data[value] = userInfo[match[1]];
+          }
+        });
+
+        debug('resourceData:', req.resourceData);
+
+        // Add info so the after handler knows to auth
+        req.oauthDeferredAuth = {
+          id: userId,
+          provider: provider.name
+        };
+      }
+    });
+  };
+
+  OAuthAction.prototype.reauthenticateNewResource = function(req, res, provider) {
+    var self = this;
+    // New resource was created and we need to authenticate it again and assign it an externalId
+    // Also confirm role is actually accessible
+    var roleQuery = hook.alter('roleQuery', {_id: self.settings.role, deleted: {$eq: null}}, req);
+    return Q.all([
+      // Load submission
+      router.formio.resources.submission.model.findOne({_id: res.resource.item._id}),
+      // Load resource
+      Q.denodeify(router.formio.cache.loadForm.bind(router.formio.cache))(req, 'resource', self.settings.resource),
+      // Load role
+      router.formio.roles.resource.model.findOne(roleQuery)
+    ])
+    .then(function(results) {
+      var submission = results[0];
+      var resource = results[1];
+      var role = results[2];
+
+      if (!submission) {
+        throw {
+          status: 404,
+          message: 'No submission found with _id: ' + res.resource.item._id
+        };
+      }
+      if (!resource) {
+        throw {
+          status: 404,
+          message: 'No resource found with _id: ' + self.settings.resource
+        };
+      }
+      if (!role) {
+        throw {
+          status: 404,
+          message: 'The given role was not found.'
+        };
+      }
+
+      // Add role
+      // Convert to just the roleId
+      debug(role);
+      role = role.toObject()._id.toString();
+
+      // Add and store unique roles only.
+      var temp = submission.toObject().roles || [];
+      debug('Submission Roles: ' + JSON.stringify(temp));
+      temp = _.map(temp, function(r) {
+        return r.toString();
+      });
+      debug('Adding: ' + role);
+      temp.push(role);
+      temp = _.uniq(temp);
+      debug('Final Roles: ' + JSON.stringify(temp));
+      temp = _.map(temp, function(r) {
+        return mongoose.Types.ObjectId(r);
+      });
+
+      submission.set('roles', temp);
+
+      // Add external id
+      submission.externalIds.push({
+        type: provider.name,
+        id: req.oauthDeferredAuth.id
+      });
+
+      return submission.save()
+      .then(function() {
+        return router.formio.auth.authenticateOAuth(resource, provider.name, req.oauthDeferredAuth.id);
+      });
+    })
+    .then(function(result) {
+      req.user = result.user;
+      req.token = result.token.decoded;
+      res.token = result.token.token;
+      req['x-jwt-token'] = result.token.token;
+      // Manually invoke router.formio.auth.currentUser to trigger resourcejs middleware.
+      return Q.nfcall(router.formio.auth.currentUser, req, res);
+    });
+  };
+
+  /**
+   * Authenticate with Form.io using OAuth
+   *
+   * Note: Requires req.body to contain an OAuth authorization code.
+   *
+   * @param req
+   *   The Express request object.
+   * @param res
+   *   The Express response object.
+   * @param next
+   *   The callback function to execute upon completion.
+   */
+  OAuthAction.prototype.resolve = function(handler, method, req, res, next) {
+    if (this.settings.association === 'new' && (!this.settings.hasOwnProperty('role') || !this.settings.role)) {
+      return next('The OAuth Action requires a Role to be selected for new resources.');
+    }
+
+    if (this.settings.association === 'existing' && this.settings.hasOwnProperty('role') && this.settings.role) {
+      this.settings = _.omit(this.settings, 'role');
+    }
+
+    if (!this.settings.provider) {
+      return next('OAuth Action is missing Provider setting.');
+    }
+
+    // Non-link association requires a resource setting
+    if (this.settings.association !== 'link' && !this.settings.resource) {
+      return next('OAuth Action is missing Resource setting.');
+    }
+
+    if (!this.settings.button) {
+      return next('OAuth Action is missing Button setting.');
+    }
+
+    var self = this;
+    var provider = router.formio.oauth.providers[this.settings.provider];
+
+    // Modify the button to be an OAuth button
+    if (
+      handler === 'after' &&
+      method === 'form' &&
+      req.query.hasOwnProperty('live') && (parseInt(req.query.live, 10) === 1) &&
+      res.hasOwnProperty('resource') &&
+      res.resource.hasOwnProperty('item') &&
+      res.resource.item._id
+    ) {
+      debug('Modifying Oauth Button');
+      oauthUtil.settings(req, provider.name)
+      .then(function(oauthSettings) {
+        if (!oauthSettings.clientId || !oauthSettings.clientSecret) {
+          next(provider.title + ' OAuth provider is missing client ID or client secret');
+        }
+        util.eachComponent(res.resource.item.components, function (component) {
+          if (component.key === self.settings.button) {
+            component.oauth = {
+              provider: provider.name,
+              clientId: oauthSettings.clientId,
+              authURI: provider.authURI,
+              state: crypto.randomBytes(64).toString('hex'),
+              scope: provider.scope,
+              display: provider.display
+            };
+          }
+        });
+        next();
+      });
+
+    }
+    else if (
+      handler === 'before' &&
+      method === 'create' &&
+      req.body.oauth &&
+      req.body.oauth[provider.name]
+    ) {
+      var oauthResponse = req.body.oauth[provider.name];
+
+      if (!oauthResponse.code || !oauthResponse.state || !oauthResponse.redirectURI) {
+        return next('No authorization code provided.');
+      }
+
+      // Do not execute the form CRUD methods.
+      req.skipResource = true;
+
+      var tokenPromise = provider.getToken(req, oauthResponse.code, oauthResponse.state, oauthResponse.redirectURI)
+      if (self.settings.association === 'new' || self.settings.association === 'existing') {
+        return tokenPromise.then(function(accessToken) {
+          return self.authenticate(req, res, provider, accessToken);
+        })
+        .then(function(){
+          next();
+        }).catch(this.onError(req, res, next));
+      }
+      else if (self.settings.association === 'link') {
+        var userId, currentUser;
+        return tokenPromise.then(function(accessToken){
+          return Q.all([
+            provider.getUser(accessToken),
+            Q.ninvoke(router.formio.auth, 'currentUser', req, res)
+          ]);
+        })
+        .then(function(results) {
+          userId = provider.getUserId(results[0]);
+          currentUser = res.resource.item;
+          debug('userId:', userId);
+          debug('currentUser:', currentUser);
+
+          if (!currentUser) {
+            throw {
+              status: 401,
+              message: 'Must be logged in to link ' + provider.title + ' account.'
+            };
+          }
+
+          // Check if this account has already been linked
+          return router.formio.resources.submission.model.findOne(
+            {
+              form: currentUser.form,
+              externalIds: {
+                $elemMatch: {
+                  type: provider.name,
+                  id: userId
+                }
+              },
+              deleted: {$eq: null}
+            }
+          );
+        }).then(function(linkedSubmission){
+          if (linkedSubmission) {
+            throw {
+              status: 400,
+              message: 'This ' + provider.title + ' account has already been linked.'
+            };
+          }
+
+          // Add the external ids
+          return router.formio.resources.submission.model.update({
+            _id: currentUser._id
+          }, {
+            $push: {
+              externalIds: {
+                type: provider.name,
+                id: userId
+              }
+            }
+          });
+        })
+        .then(function(submission) {
+          // Update current user response
+          return Q.ninvoke(router.formio.auth, 'currentUser', req, res);
+        })
+        .then(function(){
+          next();
+        }).catch(this.onError(req, res, next));
+      }
+
+
+    }
+    else if (
+      handler === 'after' &&
+      method === 'create' &&
+      req.oauthDeferredAuth &&
+      req.oauthDeferredAuth.provider === provider.name
+    ) {
+      return self.reauthenticateNewResource(req, res, provider)
+      .then(function() {
+        next();
+      })
+      .catch(this.onError(req, res, next));
+    }
+    else {
+      next();
+    }
+
+  };
+
+  OAuthAction.prototype.onError = function(req, res, next) {
+    return function(err) {
+      if(err.status) {
+        debug('Error', err);
+        return res.status(err.status).send(err.message);
+      }
+      next(err);
+    }
+  }
+
+  // Return the OAuthAction.
+  return OAuthAction;
+};

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -37,7 +37,8 @@ module.exports = function(router) {
       webhook: require('./WebhookAction')(router),
       sql: require('./SQLAction')(router),
       role: require('./RoleAction')(router),
-      resetpass: require('./ResetPassword')(router)
+      resetpass: require('./ResetPassword')(router),
+      oauth: require('./OAuthAction')(router)
     }),
 
     /**
@@ -104,7 +105,7 @@ module.exports = function(router) {
 
             // Only add the default action if it should be included.
             if (includeDefault) {
-              rows.unshift({
+              var defaultAction = {
                 title: 'Default',
                 name: 'default',
                 handler: ['before'],
@@ -112,7 +113,12 @@ module.exports = function(router) {
                 priority: 10,
                 form: form,
                 settings: {}
+              };
+              // Insert at index that keeps priority order intact
+              var index = _.sortedIndex(rows, defaultAction, function(action) {
+                return -action.priority;
               });
+              rows.splice(index, 0, defaultAction);
             }
           }
 

--- a/src/authentication/index.js
+++ b/src/authentication/index.js
@@ -15,6 +15,7 @@ var util = require('../util/util');
 
 module.exports = function(router) {
   var hook = require('../util/hook')(router.formio);
+  var oauthUtil = require('../util/oauth')(router.formio);
 
   /**
    * Generate our JWT with the given payload, and pass it to the given callback function.
@@ -39,7 +40,7 @@ module.exports = function(router) {
     }
 
     return jwt.sign(payload, router.formio.config.jwt.secret, {
-      expiresInMinutes: router.formio.config.jwt.expireTime
+      expiresIn: router.formio.config.jwt.expireTime * 60
     });
   };
 
@@ -113,6 +114,63 @@ module.exports = function(router) {
   };
 
   /**
+   * Authenticate a user via OAuth. Resolves with null if no user found
+   *
+   * @param form
+   * @param providerName
+   * @param oauthId
+   * @param next
+   *
+   * @returns {Promise}
+   */
+  var authenticateOAuth = function(form, providerName, oauthId, next) {
+    if (!providerName) {
+      return next(new Error('Missing provider'));
+    }
+    if (!oauthId) {
+      return next(new Error('Missing OAuth ID'));
+    }
+
+    return router.formio.resources.submission.model.findOne(
+      {
+        form: form._id,
+        externalIds: {
+          $elemMatch: {
+            type: providerName,
+            id: oauthId
+          }
+        },
+        deleted: {$eq: null}
+      }
+    )
+    .then(function(user) {
+      if (!user) {
+        return null;
+      }
+
+      // Respond with a token.
+      var token = hook.alter('token', {
+        user: {
+          _id: user._id,
+          roles: user.roles
+        },
+        form: {
+          _id: form._id
+        }
+      }, user, form);
+
+      return {
+        user: user,
+        token: {
+          token: getToken(token),
+          decoded: token
+        }
+      };
+    })
+    .nodeify(next);
+  };
+
+  /**
    * Send the current user.
    *
    * @param req
@@ -157,6 +215,7 @@ module.exports = function(router) {
   return {
     getToken: getToken,
     authenticate: authenticate,
+    authenticateOAuth: authenticateOAuth,
     currentUser: currentUser,
     logout: function(req, res) {
       res.setHeader('x-jwt-token', '');

--- a/src/middleware/submissionHandler.js
+++ b/src/middleware/submissionHandler.js
@@ -103,6 +103,11 @@ module.exports = function (router, resourceName, resourceId) {
             req.body.owner = _old.owner;
           }
 
+          // Keep the oauth info in the payload for the OAuthAction.
+          if (_old.hasOwnProperty('oauth') && _old.oauth && (typeof _old.oauth === 'object')) {
+            req.body.oauth = _old.oauth;
+          }
+
           // Store the original request body in a submission object.
           debug(req.body);
           req.submission = _.clone(req.body, true);

--- a/src/oauth/facebook.js
+++ b/src/oauth/facebook.js
@@ -1,0 +1,110 @@
+'use strict';
+
+var request = require('request');
+var Q = require('q');
+var url = require('url');
+
+var qRequest = Q.denodeify(request);
+
+// Export the Github oauth provider.
+module.exports = function(formio) {
+  var oauthUtil = require('../util/oauth')(formio);
+  return {
+    // Name of the oauth provider (used as property name in settings)
+    name: 'facebook',
+
+    // Display name of the oauth provider
+    title: 'Facebook',
+
+    // URL to redirect user browser to
+    authURI: 'https://www.facebook.com/v2.3/dialog/oauth',
+
+    scope: 'email',
+
+    display: 'popup',
+
+    // List of field data that can be autofilled from user info API request
+    autofillFields: [
+      {
+        title: 'Email',
+        name: 'email'
+      },
+      {
+        title: 'Name',
+        name: 'name'
+      },
+      {
+        title: 'First Name',
+        name: 'first_name'
+      },
+      {
+        title: 'Middle Name',
+        name: 'middle_name'
+      },
+      {
+        title: 'Last Name',
+        name: 'last_name'
+      }
+    ],
+
+    // TODO: have scope option to limit what permissions are asked for
+
+    // Exchanges authentication code for auth token
+    // Returns a promise, or you can provide the next callback arg
+    getToken: function(req, code, state, redirectURI, next) {
+      return oauthUtil.settings(req, this.name)
+      .then(function(settings) {
+        return qRequest({
+          method: 'POST',
+          json: true,
+          url: 'https://graph.facebook.com/v2.3/oauth/access_token',
+          body: {
+            client_id: settings.clientId,
+            client_secret: settings.clientSecret,
+            code: code,
+            state: state,
+            redirect_uri: url.parse(redirectURI).href // Facebook requires having a trailing slash
+          }
+        });
+      })
+      .then(function(result) {
+        var body = result[1]; // body is 2nd param of request
+        if (!body) {
+          throw 'No response from Facebook.';
+        }
+        if (body.error) {
+          throw body.error.message;
+        }
+        return body.access_token;
+      })
+      .nodeify(next);
+    },
+
+    // Gets user information from oauth access token
+    // Returns a promise, or you can provide the next callback arg
+    getUser: function(accessToken, next) {
+      return qRequest({
+        method: 'GET',
+        url: 'https://graph.facebook.com/v2.3/me',
+        json: true,
+        qs: {
+          access_token: accessToken,
+          fields: 'id,name,email,first_name,last_name,middle_name'
+        }
+      })
+      .then(function(result) {
+        var body = result[1]; // body is 2nd param of request
+        if (!body) {
+          throw 'No response from Facebook.';
+        }
+        return body;
+      })
+      .nodeify(next);
+    },
+
+    // Gets user ID from provider user response from getUser()
+    getUserId: function(user) {
+      return user.id;
+    }
+  };
+};

--- a/src/oauth/github.js
+++ b/src/oauth/github.js
@@ -1,0 +1,126 @@
+'use strict';
+
+var request = require('request');
+var Q = require('q');
+var _ = require('lodash');
+
+var qRequest = Q.denodeify(request);
+
+// Export the Github oauth provider.
+module.exports = function(formio) {
+  var oauthUtil = require('../util/oauth')(formio);
+  return {
+    // Name of the oauth provider (used as property name in settings)
+    name: 'github',
+
+    // Display name of the oauth provider
+    title: 'GitHub',
+
+    // URL to redirect user browser to
+    authURI: 'https://github.com/login/oauth/authorize',
+
+    scope: 'user:email',
+
+    // List of field data that can be autofilled from user info API request
+    autofillFields: [
+      {
+        title: 'Email',
+        name: 'email'
+      },
+      {
+        title: 'Username',
+        name: 'login'
+      },
+      {
+        title: 'Name',
+        name: 'name'
+      }
+    ],
+
+    // TODO: have scope option to limit what permissions are asked for
+
+    // Exchanges authentication code for auth token
+    // Returns a promise, or you can provide the next callback arg
+    getToken: function(req, code, state, redirectURI, next) {
+      return oauthUtil.settings(req, this.name)
+      .then(function(settings) {
+        return qRequest({
+          method: 'POST',
+          json: true,
+          url: 'https://github.com/login/oauth/access_token',
+          body: {
+            client_id: settings.clientId,
+            client_secret: settings.clientSecret,
+            code: code,
+            state: state
+          }
+        });
+      })
+      .then(function(result) {
+        var body = result[1]; // body is 2nd param of request
+        if (!body) {
+          throw 'No response from GitHub.';
+        }
+        if (body.error) {
+          throw body.error;
+        }
+        return body.access_token;
+      })
+      .nodeify(next);
+    },
+
+    // Gets user information from oauth access token
+    // Returns a promise, or you can provide the next callback arg
+    getUser: function(accessToken, next) {
+      return qRequest({
+        method: 'GET',
+        url: 'https://api.github.com/user',
+        json: true,
+        headers: {
+          Authorization: 'token ' + accessToken,
+          'User-Agent': 'formio'
+        }
+      })
+      .then(function(result) {
+        var userInfo = result[1]; // body is 2nd param of request
+        if (!userInfo) {
+          throw 'No response from GitHub.';
+        }
+        if(userInfo.email) {
+          return userInfo;
+        }
+        else {
+          // GitHub users can make their email private. If they do so,
+          // we have to explicitly request the email endpoint to get an email
+          return qRequest({
+            method: 'GET',
+            url: 'https://api.github.com/user/emails',
+            json: true,
+            headers: {
+              Authorization: 'token ' + accessToken,
+              'User-Agent': 'formio'
+            }
+          })
+          .then(function(result) {
+            var body = result[1]; // body is 2nd param of request
+            if(!body) {
+              throw 'No response from GitHub';
+            }
+            var primaryEmail = _.find(body, 'primary');
+            if(!primaryEmail) {
+              throw 'Could not retrieve primary email';
+            }
+            userInfo.email = primaryEmail.email;
+            return userInfo;
+          });
+        }
+      })
+      .nodeify(next);
+    },
+
+    // Gets user ID from provider user response from getUser()
+    getUserId: function(user) {
+      return user.id;
+    }
+  };
+};

--- a/src/oauth/oauth.js
+++ b/src/oauth/oauth.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = function(router) {
+
+  // Export the oauth providers.
+  return {
+    providers: {
+      github: require('./github')(router.formio),
+      facebook: require('./facebook')(router.formio)
+    }
+  };
+};

--- a/src/util/hook.js
+++ b/src/util/hook.js
@@ -1,7 +1,7 @@
 module.exports = function(formio) {
   return {
     settings: function(req, cb) {
-      var settings = formio.config.settings || {};
+      var settings = (formio.config && formio.config.settings) || {};
       if (formio.hooks && formio.hooks.settings) {
         return formio.hooks.settings(settings, req, cb);
       }

--- a/src/util/oauth.js
+++ b/src/util/oauth.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var Q = require('q');
+var _ = require('lodash');
+var _prop = require('lodash.property');
+var debug = require('debug')('formio:settings:oauth');
+
+module.exports = function(formio) {
+  var hook = require('./hook')(formio);
+  return {
+    // Gets available providers
+    // Returns a promise, or you can provide the next callback arg
+    // Resolves with array of {name, title}
+    availableProviders: function(req, next) {
+      return Q.ninvoke(hook, 'settings', req)
+      .then(function(settings) {
+        return _(settings.oauth)
+        .pick(function(provider, name) {
+          return formio.oauth.providers[name] && provider.clientId && provider.clientSecret;
+        })
+        .map(function(provider, name) {
+          return _.pick(formio.oauth.providers[name], 'name', 'title');
+        })
+        .value();
+      })
+      .nodeify(next);
+    },
+
+    // Gets settings for given oauth provider name
+    // Returns a promise, or you can provide the next callback arg
+    settings: function(req, name, next) {
+      return Q.ninvoke(hook, 'settings', req)
+      .then(function(settings) {
+        return _prop('oauth.' + name)(settings);
+      })
+      .nodeify(next);
+    }
+  };
+};

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -53,6 +53,14 @@ module.exports = {
     childReq.modelQuery = null;
     childReq.countQuery = null;
 
+    // Delete default resourceData from actions
+    // otherwise you get an endless loop
+    delete childReq.resourceData;
+
+    // Delete skipResource so child requests can decide
+    // this for themselves
+    delete childReq.skipResource;
+
     return childReq;
   },
 

--- a/test/actions.js
+++ b/test/actions.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 'use strict';
 
 var request = require('supertest');

--- a/test/auth.js
+++ b/test/auth.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 'use strict';
 
 var request = require('supertest');

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 'use strict';
 
 var express = require('express');

--- a/test/config.json
+++ b/test/config.json
@@ -11,5 +11,17 @@
   "jwt": {
     "secret": "insert-some-secret-here",
     "expireTime": 240
+  },
+  "settings": {
+    "oauth": {
+      "test1": {
+        "clientId": "TESTCLIENTID1",
+        "clientSecret": "TESTCLIENTSECRET1"
+      },
+      "test2": {
+        "clientId": "TESTCLIENTID2",
+        "clientSecret": "TESTCLIENTSECRET2"
+      }
+    }
   }
 }

--- a/test/nested.js
+++ b/test/nested.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 'use strict';
 
 var request = require('supertest');

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -1,0 +1,1318 @@
+/* eslint-env mocha */
+'use strict';
+
+var request = require('supertest');
+var assert = require('assert');
+var _ = require('lodash');
+var Q = require('q');
+var util = require('../src/util/util');
+
+module.exports = function(app, template, hook) {
+  // Cannot run these tests without access to formio instance
+  if (!app.formio) {
+    return;
+  }
+
+  describe('OAuth', function() {
+    var oauthSettings;
+
+    var TEST_AUTH_CODE_1 = 'TESTAUTHCODE1';
+    var TEST_ACCESS_TOKEN_1 = 'TESTACCESSTOKEN1';
+    var TEST_REDIRECT_URI_1 = 'http://client1.com';
+    var TEST_USER_1 = {
+      id: 23,
+      email: 'user1@test1.com'
+    };
+
+    var TEST_AUTH_CODE_2 = 'TESTAUTHCODE2';
+    var TEST_ACCESS_TOKEN_2 = 'TESTACCESSTOKEN2';
+    var TEST_REDIRECT_URI_2 = 'http://client2.com';
+    var TEST_USER_2 = {
+      id: 42,
+      email: 'user2@test2.com'
+    };
+
+    beforeEach(function() {
+      // Create a dummy oauth provider
+      app.formio.oauth.providers.test1 = {
+        name: 'test1',
+        title: 'Test1',
+        authURI: 'http://test1.com/oauth/authorize',
+        scope: 'email',
+        display: 'popup',
+        autofillFields: [{
+          title: 'Email',
+          name: 'email'
+        }],
+        getToken: function(req, code, state, redirectURI, next) {
+          assert.equal(code, TEST_AUTH_CODE_1, 'OAuth Action should request access token with expected test code.');
+          assert.equal(redirectURI, TEST_REDIRECT_URI_1, 'OAuth Action should request access token with expected redirect uri.');
+          return new Q(TEST_ACCESS_TOKEN_1).nodeify(next);
+        },
+        getUser: function(accessToken, next) {
+          assert.equal(accessToken, TEST_ACCESS_TOKEN_1,
+            'OAuth Action should request user info with expected test access token.');
+          return new Q(TEST_USER_1).nodeify(next);
+        },
+        getUserId: function(user) {
+          assert.deepEqual(user, TEST_USER_1, 'OAuth Action should get ID from expected test user.');
+          return user.id;
+        }
+      };
+
+      // Create another dummy oauth provider
+      app.formio.oauth.providers.test2 = {
+        name: 'test2',
+        title: 'Test2',
+        authURI: 'http://test2.com/oauth/authorize',
+        scope: 'email',
+        autofillFields: [{
+          title: 'Email',
+          name: 'email'
+        }],
+        getToken: function(req, code, state, redirectURI, next) {
+          assert.equal(code, TEST_AUTH_CODE_2, 'OAuth Action should request access token with expected test code.');
+          assert.equal(redirectURI, TEST_REDIRECT_URI_2, 'OAuth Action should request access token with expected redirect uri.');
+          return new Q(TEST_ACCESS_TOKEN_2).nodeify(next);
+        },
+        getUser: function(accessToken, next) {
+          assert.equal(accessToken, TEST_ACCESS_TOKEN_2,
+            'OAuth Action should request user info with expected test access token.');
+          return new Q(TEST_USER_2).nodeify(next);
+        },
+        getUserId: function(user) {
+          assert.deepEqual(user, TEST_USER_2, 'OAuth Action should get ID from expected test user.');
+          return user.id;
+        }
+      };
+    });
+
+    describe('Bootstrap', function() {
+      it('Create a User Resource for OAuth Action tests', function(done) {
+        var oauthUserResource = {
+          title: 'Oauth User',
+          name: 'oauthUser',
+          path: 'oauthuser',
+          type: 'resource',
+          access: [],
+          submissionAccess: [],
+          components: [
+            {
+              input: true,
+              inputType: 'email',
+              label: 'Email',
+              key: 'email',
+              type: 'email',
+              validate: {
+                required: true
+              }
+            },
+            {
+              input: true,
+              inputType: 'password',
+              label: 'password',
+              key: 'password',
+              type: 'password',
+              validate: {
+                required: true
+              }
+            }
+          ]
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send(oauthUserResource)
+          .expect('Content-Type', /json/)
+          .expect(201)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert(response.hasOwnProperty('modified'), 'The response should contain a `modified` timestamp.');
+            assert(response.hasOwnProperty('created'), 'The response should contain a `created` timestamp.');
+            assert(response.hasOwnProperty('access'), 'The response should contain an the `access`.');
+            assert.equal(response.title, oauthUserResource.title);
+            assert.equal(response.name, oauthUserResource.name);
+            assert.equal(response.path, oauthUserResource.path);
+            assert.equal(response.type, 'resource');
+            assert.equal(response.access.length, 1);
+            assert.equal(response.access[0].type, 'read_all');
+            assert.equal(response.access[0].roles.length, 3);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.anonymous._id.toString()), -1);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.authenticated._id.toString()), -1);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.administrator._id.toString()), -1);
+            assert.deepEqual(response.submissionAccess, []);
+            assert.deepEqual(response.components, oauthUserResource.components);
+            template.forms.oauthUserResource = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Create a Register Form for OAuth Action tests', function(done) {
+        var oauthRegisterForm = {
+          title: 'OAuth Register Form',
+          name: 'oauthRegisterForm',
+          path: 'oauthregisterform',
+          type: 'form',
+          access: [],
+          submissionAccess: [],
+          components: [
+            {
+              input: true,
+              inputType: 'email',
+              label: 'Email',
+              key: 'oauthUser.email',
+              type: 'email',
+              validate: {
+                required: true
+              }
+            },
+            {
+              input: true,
+              inputType: 'password',
+              label: 'password',
+              key: 'oauthUser.password',
+              type: 'password',
+              validate: {
+                required: true
+              }
+            },
+            {
+              input: true,
+              type: 'button',
+              theme: 'primary',
+              disableOnInvalid: 'false',
+              action: 'oauth',
+              key: 'oauthSignup1',
+              label: 'Sign-Up with Test1'
+            },
+            {
+              input: true,
+              type: 'button',
+              theme: 'primary',
+              disableOnInvalid: 'false',
+              action: 'oauth',
+              key: 'oauthSignup2',
+              label: 'Sign-Up with Test2'
+            }
+          ]
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send(oauthRegisterForm)
+          .expect('Content-Type', /json/)
+          .expect(201)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert(response.hasOwnProperty('modified'), 'The response should contain a `modified` timestamp.');
+            assert(response.hasOwnProperty('created'), 'The response should contain a `created` timestamp.');
+            assert(response.hasOwnProperty('access'), 'The response should contain an the `access`.');
+            assert.equal(response.title, oauthRegisterForm.title);
+            assert.equal(response.name, oauthRegisterForm.name);
+            assert.equal(response.path, oauthRegisterForm.path);
+            assert.equal(response.type, 'form');
+            assert.equal(response.access.length, 1);
+            assert.equal(response.access[0].type, 'read_all');
+            assert.equal(response.access[0].roles.length, 3);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.anonymous._id.toString()), -1);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.authenticated._id.toString()), -1);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.administrator._id.toString()), -1);
+            assert.deepEqual(response.submissionAccess, []);
+            assert.deepEqual(response.components, oauthRegisterForm.components);
+            template.forms.oauthRegisterForm = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Create a Login Form for OAuth Action tests', function(done) {
+        var oauthLoginForm = {
+          title: 'OAuth Login Form',
+          name: 'oauthLoginForm',
+          path: 'oauthloginform',
+          type: 'form',
+          access: [],
+          submissionAccess: [],
+          components: [
+            {
+              input: true,
+              inputType: 'email',
+              label: 'Email',
+              key: 'oauthUser.email',
+              type: 'email',
+              validate: {
+                required: true
+              }
+            },
+            {
+              input: true,
+              inputType: 'password',
+              label: 'password',
+              key: 'oauthUser.password',
+              type: 'password',
+              validate: {
+                required: true
+              }
+            },
+            {
+              input: true,
+              type: 'button',
+              theme: 'primary',
+              disableOnInvalid: 'false',
+              action: 'oauth',
+              key: 'oauthSignin1',
+              label: 'Sign-In with Test1'
+            },
+            {
+              input: true,
+              type: 'button',
+              theme: 'primary',
+              disableOnInvalid: 'false',
+              action: 'oauth',
+              key: 'oauthSignin2',
+              label: 'Sign-In with Test2'
+            }
+          ]
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send(oauthLoginForm)
+          .expect('Content-Type', /json/)
+          .expect(201)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert(response.hasOwnProperty('modified'), 'The response should contain a `modified` timestamp.');
+            assert(response.hasOwnProperty('created'), 'The response should contain a `created` timestamp.');
+            assert(response.hasOwnProperty('access'), 'The response should contain an the `access`.');
+            assert.equal(response.title, oauthLoginForm.title);
+            assert.equal(response.name, oauthLoginForm.name);
+            assert.equal(response.path, oauthLoginForm.path);
+            assert.equal(response.type, 'form');
+            assert.equal(response.access.length, 1);
+            assert.equal(response.access[0].type, 'read_all');
+            assert.equal(response.access[0].roles.length, 3);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.anonymous._id.toString()), -1);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.authenticated._id.toString()), -1);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.administrator._id.toString()), -1);
+            assert.deepEqual(response.submissionAccess, []);
+            assert.deepEqual(response.components, oauthLoginForm.components);
+            template.forms.oauthLoginForm = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Create a Link Form for OAuth Action tests', function(done) {
+        var oauthLinkForm = {
+          title: 'OAuth Link Form',
+          name: 'oauthLinkForm',
+          path: 'oauthlinkform',
+          type: 'form',
+          access: [],
+          submissionAccess: [],
+          components: [
+            {
+              input: true,
+              type: 'button',
+              theme: 'primary',
+              disableOnInvalid: 'false',
+              action: 'oauth',
+              key: 'oauthLink1',
+              label: 'Link with Test1'
+            },
+            {
+              input: true,
+              type: 'button',
+              theme: 'primary',
+              disableOnInvalid: 'false',
+              action: 'oauth',
+              key: 'oauthLink2',
+              label: 'Link with Test2'
+            }
+          ]
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send(oauthLinkForm)
+          .expect('Content-Type', /json/)
+          .expect(201)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert(response.hasOwnProperty('modified'), 'The response should contain a `modified` timestamp.');
+            assert(response.hasOwnProperty('created'), 'The response should contain a `created` timestamp.');
+            assert(response.hasOwnProperty('access'), 'The response should contain an the `access`.');
+            assert.equal(response.title, oauthLinkForm.title);
+            assert.equal(response.name, oauthLinkForm.name);
+            assert.equal(response.path, oauthLinkForm.path);
+            assert.equal(response.type, 'form');
+            assert.equal(response.access.length, 1);
+            assert.equal(response.access[0].type, 'read_all');
+            assert.equal(response.access[0].roles.length, 3);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.anonymous._id.toString()), -1);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.authenticated._id.toString()), -1);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.administrator._id.toString()), -1);
+            assert.deepEqual(response.submissionAccess, []);
+            assert.deepEqual(response.components, oauthLinkForm.components);
+            template.forms.oauthLinkForm = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Set up submission create_own access for Anonymous users for Register Form', function(done) {
+        request(app)
+          .put(hook.alter('url', '/form/' + template.forms.oauthRegisterForm._id, template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send({submissionAccess: [{
+            type: 'create_own',
+            roles: [template.roles.anonymous._id.toString()]
+          }]})
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert.equal(response.submissionAccess[0].type, 'create_own');
+            assert.equal(response.submissionAccess[0].roles.length, 1);
+            assert.equal(response.submissionAccess[0].roles[0], template.roles.anonymous._id.toString());
+
+            // Save this form for later use.
+            template.forms.oauthRegisterForm = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Set up submission create_own access for Anonymous users for Login Form', function(done) {
+        request(app)
+          .put(hook.alter('url', '/form/' + template.forms.oauthLoginForm._id, template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send({submissionAccess: [{
+            type: 'create_own',
+            roles: [template.roles.anonymous._id.toString()]
+          }]})
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert.equal(response.submissionAccess[0].type, 'create_own');
+            assert.equal(response.submissionAccess[0].roles.length, 1);
+            assert.equal(response.submissionAccess[0].roles[0], template.roles.anonymous._id.toString());
+
+            // Save this form for later use.
+            template.forms.oauthLoginForm = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Set up submission create_own access for Authenticated users for Link Form', function(done) {
+        request(app)
+          .put(hook.alter('url', '/form/' + template.forms.oauthLinkForm._id, template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send({submissionAccess: [{
+            type: 'create_own',
+            roles: [template.roles.authenticated._id.toString()]
+          }]})
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert.equal(response.submissionAccess[0].type, 'create_own');
+            assert.equal(response.submissionAccess[0].roles.length, 1);
+            assert.equal(response.submissionAccess[0].roles[0], template.roles.authenticated._id.toString());
+
+            // Save this form for later use.
+            template.forms.oauthLinkForm = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      // We attach Auth actions because oauth is supposed to override
+      // them and prevent them from returning errors.
+      it('Create AuthAction for Register Form', function(done) {
+        var authRegisterAction = {
+          title: 'Authentication',
+          name: 'auth',
+          handler: ['before'],
+          method: ['create'],
+          priority: 0,
+          settings: {
+            association: 'new',
+            role: template.roles.authenticated._id.toString(),
+            username: 'oauthUser.email',
+            password: 'oauthUser.password'
+          }
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.oauthRegisterForm._id + '/action', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send(authRegisterAction)
+          .expect('Content-Type', /json/)
+          .expect(201)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert.equal(response.title, authRegisterAction.title);
+            assert.equal(response.name, authRegisterAction.name);
+            assert.deepEqual(response.handler, authRegisterAction.handler);
+            assert.deepEqual(response.method, authRegisterAction.method);
+            assert.equal(response.priority, authRegisterAction.priority);
+            assert.deepEqual(response.settings, authRegisterAction.settings);
+            assert.equal(response.form, template.forms.oauthRegisterForm._id);
+            template.actions.authRegisterAction = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Create AuthAction for Login Form', function(done) {
+        var authLoginAction = {
+          title: 'Authentication',
+          name: 'auth',
+          handler: ['before'],
+          method: ['create'],
+          priority: 0,
+          settings: {
+            association: 'existing',
+            username: 'oauthUser.email',
+            password: 'oauthUser.password'
+          }
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.oauthLoginForm._id + '/action', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send(authLoginAction)
+          .expect('Content-Type', /json/)
+          .expect(201)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert.equal(response.title, authLoginAction.title);
+            assert.equal(response.name, authLoginAction.name);
+            assert.deepEqual(response.handler, authLoginAction.handler);
+            assert.deepEqual(response.method, authLoginAction.method);
+            assert.equal(response.priority, authLoginAction.priority);
+            assert.deepEqual(response.settings, authLoginAction.settings);
+            assert.equal(response.form, template.forms.oauthLoginForm._id);
+            authLoginAction = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Create OAuthAction for test1 provider for Register Form', function(done) {
+        var oauthRegisterAction1 = {
+          title: 'OAuth',
+          name: 'oauth',
+          handler: ['after', 'before'],
+          method: ['form', 'create'],
+          priority: 20,
+          settings: {
+            provider: 'test1',
+            association: 'new',
+            resource: template.forms.oauthUserResource._id,
+            role: template.roles.authenticated._id.toString(),
+            button: 'oauthSignup1',
+            'autofill-test1-email': 'oauthUser.email'
+          }
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.oauthRegisterForm._id + '/action', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send(oauthRegisterAction1)
+          .expect('Content-Type', /json/)
+          .expect(201)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert.equal(response.title, oauthRegisterAction1.title);
+            assert.equal(response.name, oauthRegisterAction1.name);
+            assert.deepEqual(response.handler, oauthRegisterAction1.handler);
+            assert.deepEqual(response.method, oauthRegisterAction1.method);
+            assert.equal(response.priority, oauthRegisterAction1.priority);
+            assert.deepEqual(response.settings, oauthRegisterAction1.settings);
+            assert.equal(response.form, template.forms.oauthRegisterForm._id);
+            oauthRegisterAction1 = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Create OAuthAction for test1 provider for Login Form', function(done) {
+        var oauthLoginAction1 = {
+          title: 'OAuth',
+          name: 'oauth',
+          handler: ['after', 'before'],
+          method: ['form', 'create'],
+          priority: 20,
+          settings: {
+            provider: 'test1',
+            association: 'existing',
+            resource: template.forms.oauthUserResource._id,
+            button: 'oauthSignin1'
+          }
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.oauthLoginForm._id + '/action', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send(oauthLoginAction1)
+          .expect('Content-Type', /json/)
+          .expect(201)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert.equal(response.title, oauthLoginAction1.title);
+            assert.equal(response.name, oauthLoginAction1.name);
+            assert.deepEqual(response.handler, oauthLoginAction1.handler);
+            assert.deepEqual(response.method, oauthLoginAction1.method);
+            assert.equal(response.priority, oauthLoginAction1.priority);
+            assert.deepEqual(response.settings, oauthLoginAction1.settings);
+            assert.equal(response.form, template.forms.oauthLoginForm._id);
+            oauthLoginAction1 = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Create OAuthAction for test1 provider for Link Form', function(done) {
+        var oauthLinkAction1 = {
+          title: 'OAuth',
+          name: 'oauth',
+          handler: ['after', 'before'],
+          method: ['form', 'create'],
+          priority: 20,
+          settings: {
+            provider: 'test1',
+            association: 'link',
+            button: 'oauthSignin1'
+          }
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.oauthLinkForm._id + '/action', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send(oauthLinkAction1)
+          .expect('Content-Type', /json/)
+          .expect(201)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert.equal(response.title, oauthLinkAction1.title);
+            assert.equal(response.name, oauthLinkAction1.name);
+            assert.deepEqual(response.handler, oauthLinkAction1.handler);
+            assert.deepEqual(response.method, oauthLinkAction1.method);
+            assert.equal(response.priority, oauthLinkAction1.priority);
+            assert.deepEqual(response.settings, oauthLinkAction1.settings);
+            assert.equal(response.form, template.forms.oauthLinkForm._id);
+            oauthLinkAction1 = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Create OAuthAction for test2 provider for Register Form', function(done) {
+        var oauthRegisterAction2 = {
+          title: 'OAuth',
+          name: 'oauth',
+          handler: ['after', 'before'],
+          method: ['form', 'create'],
+          priority: 20,
+          settings: {
+            provider: 'test2',
+            association: 'new',
+            resource: template.forms.oauthUserResource._id,
+            role: template.roles.authenticated._id.toString(),
+            button: 'oauthSignup2',
+            'autofill-test2-email': 'oauthUser.email'
+          }
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.oauthRegisterForm._id + '/action', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send(oauthRegisterAction2)
+          .expect('Content-Type', /json/)
+          .expect(201)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert.equal(response.title, oauthRegisterAction2.title);
+            assert.equal(response.name, oauthRegisterAction2.name);
+            assert.deepEqual(response.handler, oauthRegisterAction2.handler);
+            assert.deepEqual(response.method, oauthRegisterAction2.method);
+            assert.equal(response.priority, oauthRegisterAction2.priority);
+            assert.deepEqual(response.settings, oauthRegisterAction2.settings);
+            assert.equal(response.form, template.forms.oauthRegisterForm._id);
+            oauthRegisterAction2 = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Create OAuthAction for test2 provider for Login Form', function(done) {
+        var oauthLoginAction2 = {
+          title: 'OAuth',
+          name: 'oauth',
+          handler: ['after', 'before'],
+          method: ['form', 'create'],
+          priority: 20,
+          settings: {
+            provider: 'test2',
+            association: 'existing',
+            resource: template.forms.oauthUserResource._id,
+            button: 'oauthSignin2'
+          }
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.oauthLoginForm._id + '/action', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send(oauthLoginAction2)
+          .expect('Content-Type', /json/)
+          .expect(201)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert.equal(response.title, oauthLoginAction2.title);
+            assert.equal(response.name, oauthLoginAction2.name);
+            assert.deepEqual(response.handler, oauthLoginAction2.handler);
+            assert.deepEqual(response.method, oauthLoginAction2.method);
+            assert.equal(response.priority, oauthLoginAction2.priority);
+            assert.deepEqual(response.settings, oauthLoginAction2.settings);
+            assert.equal(response.form, template.forms.oauthLoginForm._id);
+            oauthLoginAction2 = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Create OAuthAction for test2 provider for Link Form', function(done) {
+        var oauthLinkAction2 = {
+          title: 'OAuth',
+          name: 'oauth',
+          handler: ['after', 'before'],
+          method: ['form', 'create'],
+          priority: 20,
+          settings: {
+            provider: 'test2',
+            association: 'link',
+            button: 'oauthSignin2'
+          }
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.oauthLinkForm._id + '/action', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send(oauthLinkAction2)
+          .expect('Content-Type', /json/)
+          .expect(201)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert.equal(response.title, oauthLinkAction2.title);
+            assert.equal(response.name, oauthLinkAction2.name);
+            assert.deepEqual(response.handler, oauthLinkAction2.handler);
+            assert.deepEqual(response.method, oauthLinkAction2.method);
+            assert.equal(response.priority, oauthLinkAction2.priority);
+            assert.deepEqual(response.settings, oauthLinkAction2.settings);
+            assert.equal(response.form, template.forms.oauthLinkForm._id);
+            oauthLinkAction2 = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Get OAuth settings', function(done) {
+        hook.settings(null, function(err, settings) {
+          if (err) {
+            return done(err);
+          }
+          oauthSettings = settings.oauth;
+          assert(oauthSettings.test1);
+          assert(oauthSettings.test1.clientId);
+          assert(oauthSettings.test1.clientSecret);
+          assert(oauthSettings.test2);
+          assert(oauthSettings.test2.clientId);
+          assert(oauthSettings.test2.clientSecret);
+          done();
+        });
+      });
+
+    });
+
+    describe('After Form Handler', function() {
+      it('Should not modify a Form Read without ?live=1', function(done) {
+        request(app)
+          .get(hook.alter('url', '/form/' + template.forms.oauthRegisterForm._id, template))
+          .set('x-jwt-token', template.users.admin.token)
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert.deepEqual(response, template.forms.oauthRegisterForm);
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Should modify a Form Read with ?live=1', function(done) {
+        request(app)
+          .get(hook.alter('url', '/form/' + template.forms.oauthRegisterForm._id + '?live=1', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            response.components = util.flattenComponents(response.components);
+            var flattenedComponents = util.flattenComponents(template.forms.oauthRegisterForm.components);
+            _.each(response.components, function(component, i) {
+              if (component.action === 'oauth') {
+                if (component.key === 'oauthSignup1') {
+                  assert.equal(component.oauth.provider, app.formio.oauth.providers.test1.name);
+                  assert.equal(component.oauth.clientId, oauthSettings.test1.clientId);
+                  assert.equal(component.oauth.authURI, app.formio.oauth.providers.test1.authURI);
+                  assert.equal(component.oauth.scope, app.formio.oauth.providers.test1.scope);
+                  assert.equal(component.oauth.display, app.formio.oauth.providers.test1.display);
+                }
+                if (component.key === 'oauthSignup2') {
+                  assert.equal(component.oauth.provider, app.formio.oauth.providers.test2.name);
+                  assert.equal(component.oauth.clientId, oauthSettings.test2.clientId);
+                  assert.equal(component.oauth.authURI, app.formio.oauth.providers.test2.authURI);
+                  assert.equal(component.oauth.scope, app.formio.oauth.providers.test2.scope);
+                  assert.equal(component.oauth.display, app.formio.oauth.providers.test2.display);
+                }
+                assert.deepEqual(_.omit(component, 'oauth'), flattenedComponents[i],
+                  'OAuth button should only have oauth prop added');
+              }
+              else {
+                assert.deepEqual(component, flattenedComponents[i], 'Non oauth buttons should remain unchanged');
+              }
+            });
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+    });
+
+    describe('OAuth Submission Handler', function() {
+
+      it('An anonymous user should be able to register with OAuth provider test1', function(done) {
+        var submission = {
+          data: {},
+          oauth: {
+            test1: {
+              code: TEST_AUTH_CODE_1,
+              state: 'teststate', // Scope only matters for client side validation
+              redirectURI: TEST_REDIRECT_URI_1
+            }
+          }
+        };
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.oauthRegisterForm._id + '/submission', template))
+          .send(submission)
+          // .expect(200)
+          // .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert(response.hasOwnProperty('modified'), 'The response should contain a `modified` timestamp.');
+            assert(response.hasOwnProperty('created'), 'The response should contain a `created` timestamp.');
+            assert(response.hasOwnProperty('data'), 'The response should contain a submission `data` object.');
+            assert.equal(response.data.email, TEST_USER_1.email, 'The OAuth Action should autofill the email field.');
+            assert.equal(response.form, template.forms.oauthUserResource._id, 'The submission returned should be for the authenticated resource.');
+            assert(response.hasOwnProperty('roles'), 'The response should contain the resource `roles`.');
+            assert.deepEqual(response.roles, [template.roles.authenticated._id.toString()], 'The submission should have the OAuth Action configured role added to it.');
+            assert.equal(response.externalIds.length, 1);
+            assert(response.externalIds[0].hasOwnProperty('_id'), 'The externalId should contain an `_id`.');
+            assert(response.externalIds[0].hasOwnProperty('modified'), 'The externalId should contain a `modified` timestamp.');
+            assert(response.externalIds[0].hasOwnProperty('created'), 'The externalId should contain a `created` timestamp.');
+            assert.equal(response.externalIds[0].type, app.formio.oauth.providers.test1.name, 'The externalId should be for test1 oauth.');
+            assert.equal(response.externalIds[0].id, TEST_USER_1.id, 'The externalId should match test user 1\'s id.');
+            assert(!response.hasOwnProperty('deleted'), 'The response should not contain `deleted`');
+            assert(!response.hasOwnProperty('__v'), 'The response should not contain `__v`');
+            assert(res.headers.hasOwnProperty('x-jwt-token'), 'The response should contain a `x-jwt-token` header.');
+
+            // Save user for later tests
+            template.users.oauthUser1 = response;
+            template.users.oauthUser1.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('An anonymous user should be able to register with OAuth provider test2', function(done) {
+        var submission = {
+          data: {},
+          oauth: {
+            test2: {
+              code: TEST_AUTH_CODE_2,
+              state: 'teststate', // Scope only matters for client side validation
+              redirectURI: TEST_REDIRECT_URI_2
+            }
+          }
+        };
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.oauthRegisterForm._id + '/submission', template))
+          .send(submission)
+          .expect(200)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert(response.hasOwnProperty('modified'), 'The response should contain a `modified` timestamp.');
+            assert(response.hasOwnProperty('created'), 'The response should contain a `created` timestamp.');
+            assert(response.hasOwnProperty('data'), 'The response should contain a submission `data` object.');
+            assert.equal(response.data.email, TEST_USER_2.email, 'The OAuth Action should autofill the email field.');
+            assert.equal(response.form, template.forms.oauthUserResource._id, 'The submission returned should be for the authenticated resource.');
+            assert(response.hasOwnProperty('roles'), 'The response should contain the resource `roles`.');
+            assert.deepEqual(response.roles, [template.roles.authenticated._id.toString()], 'The submission should have the OAuth Action configured role added to it.');
+            assert.equal(response.externalIds.length, 1);
+            assert(response.externalIds[0].hasOwnProperty('_id'), 'The externalId should contain an `_id`.');
+            assert(response.externalIds[0].hasOwnProperty('modified'), 'The externalId should contain a `modified` timestamp.');
+            assert(response.externalIds[0].hasOwnProperty('created'), 'The externalId should contain a `created` timestamp.');
+            assert.equal(response.externalIds[0].type, app.formio.oauth.providers.test2.name, 'The externalId should be for test2 oauth.');
+            assert.equal(response.externalIds[0].id, TEST_USER_2.id, 'The externalId should match test user 2\'s id.');
+            assert(!response.hasOwnProperty('deleted'), 'The response should not contain `deleted`');
+            assert(!response.hasOwnProperty('__v'), 'The response should not contain `__v`');
+            assert(res.headers.hasOwnProperty('x-jwt-token'), 'The response should contain a `x-jwt-token` header.');
+
+            // Save user for later tests
+            template.users.oauthUser2 = response;
+            template.users.oauthUser2.token = res.headers['x-jwt-token'];
+            done();
+          });
+      });
+
+      it('An anonymous user should be able to login with OAuth provider test1', function(done) {
+        var submission = {
+          data: {},
+          oauth: {
+            test1: {
+              code: TEST_AUTH_CODE_1,
+              state: 'teststate', // Scope only matters for client side validation
+              redirectURI: TEST_REDIRECT_URI_1
+            }
+          }
+        };
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.oauthLoginForm._id + '/submission', template))
+          .send(submission)
+          .expect(200)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert(response.hasOwnProperty('modified'), 'The response should contain a `modified` timestamp.');
+            assert(response.hasOwnProperty('created'), 'The response should contain a `created` timestamp.');
+            assert(response.hasOwnProperty('data'), 'The response should contain a submission `data` object.');
+            assert.equal(response.data.email, TEST_USER_1.email, 'The OAuth Action should return a user with the right email.');
+            assert.equal(response.form, template.forms.oauthUserResource._id, 'The submission returned should be for the authenticated resource.');
+            assert(response.hasOwnProperty('roles'), 'The response should contain the resource `roles`.');
+            assert.deepEqual(response.roles, [template.roles.authenticated._id.toString()], 'The submission should have the OAuth Action configured role.');
+            assert.equal(response.externalIds.length, 1);
+            assert(response.externalIds[0].hasOwnProperty('_id'), 'The externalId should contain an `_id`.');
+            assert(response.externalIds[0].hasOwnProperty('modified'), 'The externalId should contain a `modified` timestamp.');
+            assert(response.externalIds[0].hasOwnProperty('created'), 'The externalId should contain a `created` timestamp.');
+            assert.equal(response.externalIds[0].type, app.formio.oauth.providers.test1.name, 'The externalId should be for test1 oauth.');
+            assert.equal(response.externalIds[0].id, TEST_USER_1.id, 'The externalId should match test user 1\'s id.');
+            assert(!response.hasOwnProperty('deleted'), 'The response should not contain `deleted`');
+            assert(!response.hasOwnProperty('__v'), 'The response should not contain `__v`');
+            assert(res.headers.hasOwnProperty('x-jwt-token'), 'The response should contain a `x-jwt-token` header.');
+
+            done();
+          });
+      });
+
+      it('An anonymous user should be able to login with OAuth provider test2', function(done) {
+        var submission = {
+          data: {},
+          oauth: {
+            test2: {
+              code: TEST_AUTH_CODE_2,
+              state: 'teststate', // Scope only matters for client side validation
+              redirectURI: TEST_REDIRECT_URI_2
+            }
+          }
+        };
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.oauthLoginForm._id + '/submission', template))
+          .send(submission)
+          .expect(200)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert(response.hasOwnProperty('modified'), 'The response should contain a `modified` timestamp.');
+            assert(response.hasOwnProperty('created'), 'The response should contain a `created` timestamp.');
+            assert(response.hasOwnProperty('data'), 'The response should contain a submission `data` object.');
+            assert.equal(response.data.email, TEST_USER_2.email, 'The OAuth Action should return a user with the right email.');
+            assert.equal(response.form, template.forms.oauthUserResource._id, 'The submission returned should be for the authenticated resource.');
+            assert(response.hasOwnProperty('roles'), 'The response should contain the resource `roles`.');
+            assert.deepEqual(response.roles, [template.roles.authenticated._id.toString()], 'The submission should have the OAuth Action configured role.');
+            assert.equal(response.externalIds.length, 1);
+            assert(response.externalIds[0].hasOwnProperty('_id'), 'The externalId should contain an `_id`.');
+            assert(response.externalIds[0].hasOwnProperty('modified'), 'The externalId should contain a `modified` timestamp.');
+            assert(response.externalIds[0].hasOwnProperty('created'), 'The externalId should contain a `created` timestamp.');
+            assert.equal(response.externalIds[0].type, app.formio.oauth.providers.test2.name, 'The externalId should be for test2 oauth.');
+            assert.equal(response.externalIds[0].id, TEST_USER_2.id, 'The externalId should match test user 2\'s id.');
+            assert(!response.hasOwnProperty('deleted'), 'The response should not contain `deleted`');
+            assert(!response.hasOwnProperty('__v'), 'The response should not contain `__v`');
+            assert(res.headers.hasOwnProperty('x-jwt-token'), 'The response should contain a `x-jwt-token` header.');
+
+            done();
+          });
+      });
+
+      it('An anonymous user should be logged in when registering with a previously registered OAuth provider test1 account', function(done) {
+        var submission = {
+          data: {},
+          oauth: {
+            test1: {
+              code: TEST_AUTH_CODE_1,
+              state: 'teststate', // Scope only matters for client side validation
+              redirectURI: TEST_REDIRECT_URI_1
+            }
+          }
+        };
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.oauthRegisterForm._id + '/submission', template))
+          .send(submission)
+          .expect(200)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert.deepEqual(response, _.omit(template.users.oauthUser1, 'token'), 'The response should match the previously registered user');
+            assert(res.headers.hasOwnProperty('x-jwt-token'), 'The response should contain a `x-jwt-token` header.');
+
+            done();
+          });
+      });
+
+      it('An anonymous user should receive an error when logging in with an unlinked OAuth provider test2 account', function(done) {
+        // Test values for 3rd unlinked test user
+        var TEST_AUTH_CODE_3 = 'TESTAUTHCODE3';
+        var TEST_ACCESS_TOKEN_3 = 'TESTACCESSTOKEN3';
+        var TEST_REDIRECT_URI_3 = 'http://client3.com';
+        var TEST_USER_3 = {
+          id: 777,
+          email: 'user3@test3.com'
+        };
+        // Extend and modify dummy oauth provider to return 3rd unlinked test user
+        app.formio.oauth.providers.test2 = _.create(app.formio.oauth.providers.test2, {
+          getToken: function(req, code, state, redirectURI, next) {
+            assert.equal(code, TEST_AUTH_CODE_3, 'OAuth Action should request access token with expected test code.');
+            assert.equal(redirectURI, TEST_REDIRECT_URI_3, 'OAuth Action should request access token with expected redirect uri.');
+            return new Q(TEST_ACCESS_TOKEN_3).nodeify(next);
+          },
+          getUser: function(accessToken, next) {
+            assert.equal(accessToken, TEST_ACCESS_TOKEN_3,
+              'OAuth Action should request user info with expected test access token.');
+            return new Q(TEST_USER_3).nodeify(next);
+          },
+          getUserId: function(user) {
+            assert.deepEqual(user, TEST_USER_3, 'OAuth Action should get ID from expected test user.');
+            return user.id;
+          }
+        });
+        var submission = {
+          data: {},
+          oauth: {
+            test2: {
+              code: TEST_AUTH_CODE_3,
+              state: 'teststate', // Scope only matters for client side validation
+              redirectURI: TEST_REDIRECT_URI_3
+            }
+          }
+        };
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.oauthLoginForm._id + '/submission', template))
+          .send(submission)
+          .expect(404)
+          .end(done);
+      });
+
+      it('A test1 user should be able to link his submission to his OAuth provider test2 account', function(done) {
+        // Test values for 4rd unlinked test user
+        var TEST_AUTH_CODE_4 = 'TESTAUTHCODE4';
+        var TEST_ACCESS_TOKEN_4 = 'TESTACCESSTOKEN4';
+        var TEST_REDIRECT_URI_4 = 'http://client4.com';
+        var TEST_USER_4 = {
+          id: 808,
+          email: 'user1@test2.com'
+        };
+        // Extend and modify dummy oauth provider to return 4th unlinked test user
+        app.formio.oauth.providers.test2 = _.create(app.formio.oauth.providers.test2, {
+          getToken: function(req, code, state, redirectURI, next) {
+            assert.equal(code, TEST_AUTH_CODE_4, 'OAuth Action should request access token with expected test code.');
+            assert.equal(redirectURI, TEST_REDIRECT_URI_4, 'OAuth Action should request access token with expected redirect uri.');
+            return new Q(TEST_ACCESS_TOKEN_4).nodeify(next);
+          },
+          getUser: function(accessToken, next) {
+            assert.equal(accessToken, TEST_ACCESS_TOKEN_4,
+              'OAuth Action should request user info with expected test access token.');
+            return new Q(TEST_USER_4).nodeify(next);
+          },
+          getUserId: function(user) {
+            assert.deepEqual(user, TEST_USER_4, 'OAuth Action should get ID from expected test user.');
+            return user.id;
+          }
+        });
+        var submission = {
+          data: {},
+          oauth: {
+            test2: {
+              code: TEST_AUTH_CODE_4,
+              state: 'teststate', // Scope only matters for client side validation
+              redirectURI: TEST_REDIRECT_URI_4
+            }
+          }
+        };
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.oauthLinkForm._id + '/submission', template))
+          .set('x-jwt-token', template.users.oauthUser1.token)
+          .send(submission)
+          .expect(200)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert.deepEqual(
+              _.omit(response, 'externalIds'),
+              _.omit(template.users.oauthUser1, 'token', 'externalIds'),
+              'The response should match the previously registered user');
+            assert.equal(response.externalIds.length, 2);
+            assert.notEqual(_.find(response.externalIds, {
+              id: '' + TEST_USER_1.id
+            }), undefined, 'The response should have a test1 external id');
+            assert.notEqual(_.find(response.externalIds, {
+              type: app.formio.oauth.providers.test2.name,
+              id: '' + TEST_USER_4.id
+            }), undefined, 'The response should have a test2 external id');
+            assert(res.headers.hasOwnProperty('x-jwt-token'), 'The response should contain a `x-jwt-token` header.');
+
+            done();
+          });
+      });
+
+      it('An anonymous user should get an error when trying to link an account', function(done) {
+        // Test values for 5rd unlinked test user
+        var TEST_AUTH_CODE_5 = 'TESTAUTHCODE5';
+        var TEST_ACCESS_TOKEN_5 = 'TESTACCESSTOKEN5';
+        var TEST_REDIRECT_URI_5 = 'http://client5.com';
+        var TEST_USER_5 = {
+          id: 808,
+          email: 'user5@test5.com'
+        };
+        // Extend and modify dummy oauth provider to return 5th unlinked test user
+        app.formio.oauth.providers.test2 = _.create(app.formio.oauth.providers.test2, {
+          getToken: function(req, code, state, redirectURI, next) {
+            assert.equal(code, TEST_AUTH_CODE_5, 'OAuth Action should request access token with expected test code.');
+            assert.equal(redirectURI, TEST_REDIRECT_URI_5, 'OAuth Action should request access token with expected redirect uri.');
+            return new Q(TEST_ACCESS_TOKEN_5).nodeify(next);
+          },
+          getUser: function(accessToken, next) {
+            assert.equal(accessToken, TEST_ACCESS_TOKEN_5,
+              'OAuth Action should request user info with expected test access token.');
+            return new Q(TEST_USER_5).nodeify(next);
+          },
+          getUserId: function(user) {
+            assert.deepEqual(user, TEST_USER_5, 'OAuth Action should get ID from expected test user.');
+            return user.id;
+          }
+        });
+        var submission = {
+          data: {},
+          oauth: {
+            test2: {
+              code: TEST_AUTH_CODE_5,
+              state: 'teststate', // Scope only matters for client side validation
+              redirectURI: TEST_REDIRECT_URI_5
+            }
+          }
+        };
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.oauthLinkForm._id + '/submission', template))
+          .send(submission)
+          .expect(401)
+          .end(done);
+      });
+
+      it('A user should get an error when trying to link an already linked account', function(done) {
+        var submission = {
+          data: {},
+          oauth: {
+            test1: {
+              code: TEST_AUTH_CODE_1,
+              state: 'teststate', // Scope only matters for client side validation
+              redirectURI: TEST_REDIRECT_URI_1
+            }
+          }
+        };
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.oauthLinkForm._id + '/submission', template))
+          .set('x-jwt-token', template.users.oauthUser2.token)
+          .send(submission)
+          .expect(400)
+          .end(done);
+      });
+
+    });
+  });
+};

--- a/test/resource.js
+++ b/test/resource.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 'use strict';
 
 var request = require('supertest');

--- a/test/roles.js
+++ b/test/roles.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 'use strict';
 
 var request = require('supertest');

--- a/test/submission.js
+++ b/test/submission.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 'use strict';
 
 var request = require('supertest');

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 'use strict';
 
 var Q = require('q');
@@ -14,7 +15,7 @@ var hook = null;
 require('./bootstrap')()
   .then(function(state) {
     app = state.app;
-    hook = require('../src/util/hook')({});
+    hook = require('../src/util/hook')(state.app.formio);
     template = state.template;
     ready.resolve();
   });
@@ -85,5 +86,6 @@ describe('Bootstrap Test modules', function() {
     require('./nested')(app, template, hook);
     require('./actions')(app, template, hook);
     require('./submission')(app, template, hook);
+    require('./oauth')(app, template, hook);
   });
 });


### PR DESCRIPTION
Also:
 - Added tests for OAuth
 - Added filtering queries to /form/:formId/components endpoint (though ultimately unused by OAuthAction)
 - Added tests for filtering queries
 - Made DefaultAction honor priority instead of always running first
 - Fixed jwt deprecation warning
 - Fixed hooks crashing with empty config