### PR TITLE
FA-489 Added Office 365 OAuth + Storing OAuth tokens in submissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "chance": "^0.8.0",
     "eslint": "^0.20.0",
     "mocha": "^2.2.1",
+    "sinon": "^1.17.2",
     "supertest": "^0.15.0"
   },
   "directories": {

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -442,7 +442,7 @@ module.exports = function(router) {
       router.formio.middleware.filterMongooseExists({field: 'deleted', isNull: true}),
       actionPayload
     ];
-    handlers['after' + method] = [router.formio.middleware.filterResourcejsResponse(['deleted', '__v'])];
+    handlers['after' + method] = [router.formio.middleware.filterResourcejsResponse(['deleted', '__v', 'externalTokens'])];
   });
 
   // Add specific middleware to individual endpoints.

--- a/src/authentication/index.js
+++ b/src/authentication/index.js
@@ -15,7 +15,6 @@ var util = require('../util/util');
 
 module.exports = function(router) {
   var hook = require('../util/hook')(router.formio);
-  var oauthUtil = require('../util/oauth')(router.formio);
 
   /**
    * Generate our JWT with the given payload, and pass it to the given callback function.

--- a/src/models/Submission.js
+++ b/src/models/Submission.js
@@ -8,6 +8,13 @@ var ExternalIdSchema = mongoose.Schema({
   id: String
 });
 
+// Defines what each external Token should be.
+var ExternalTokenSchema = mongoose.Schema({
+  type: String,
+  token: String,
+  exp: Date
+});
+
 // Add timestamps to the external ids.
 ExternalIdSchema.plugin(require('../plugins/timestamps'));
 
@@ -42,6 +49,9 @@ module.exports = function(formio) {
 
       // An array of external Id's.
       externalIds: [ExternalIdSchema],
+
+      // An array of external tokens.
+      externalTokens: [ExternalTokenSchema],
 
       // The data associated with this submission.
       data: {

--- a/src/oauth/oauth.js
+++ b/src/oauth/oauth.js
@@ -1,12 +1,53 @@
 'use strict';
 
+var Q = require('q');
+var _ = require('lodash');
+var debug = require('debug')('formio:oauth');
+
 module.exports = function(router) {
 
   // Export the oauth providers.
   return {
     providers: {
       github: require('./github')(router.formio),
-      facebook: require('./facebook')(router.formio)
+      facebook: require('./facebook')(router.formio),
+      office365: require('./office365')(router.formio)
+    },
+
+    // Gets user token for a provider, and attempts to refresh it
+    // if it is expired
+    // Returns a promise, or you can provide the next callback arg
+    getUserToken: function(req, res, providerName, userId, next) {
+      var provider = this.providers[providerName];
+      if (!provider) {
+        return Q.reject('Invalid provider name');
+      }
+
+      return router.formio.resources.submission.model.findOne({_id: userId})
+      .then(function(user) {
+        if (!user) {
+          throw 'Could not find user';
+        }
+        var accessToken = _.find(user.externalTokens, {type: provider.name});
+        if (!accessToken) {
+          throw 'No access token available. Make sure you have authenticated with ' + provider.title + '.';
+        }
+        if (new Date() < accessToken.exp) {
+          return accessToken.token;
+        }
+
+        debug('Access Token is expired, refreshing...');
+
+        return provider.refreshTokens(req, res, user)
+        .then(function(tokens) {
+          user.set('externalTokens',
+            _(tokens).concat(user.externalTokens).uniq('type').value()
+          );
+
+          return Q(user.save()).thenResolve(_.find(tokens, {type: provider.name}).token);
+        });
+      })
+      .nodeify(next);
     }
   };
 };

--- a/src/oauth/office365.js
+++ b/src/oauth/office365.js
@@ -1,0 +1,208 @@
+'use strict';
+
+var Q = require('q');
+var _ = require('lodash');
+var uuid = require('node-uuid');
+var AuthenticationContext = require('adal-node').AuthenticationContext;
+
+var util = require('../util/util');
+
+var checkMissing = function(settings) {
+  var o365Settings = settings.office365;
+
+  // Check if any required settings are missing
+  if (!o365Settings) {
+    return 'Office 365 settings';
+  }
+  if (!o365Settings.tenant) {
+    return 'Office 365 Tenant';
+  }
+  if (!o365Settings.clientId) {
+    return 'Office 365 Client Id';
+  }
+  if (!o365Settings.clientSecret) {
+    return 'Office 365 Client Secret';
+  }
+};
+
+// Export the Github oauth provider.
+module.exports = function(formio) {
+  var hook = require('../util/hook')(formio);
+  return {
+    // Name of the oauth provider (used as property name in settings)
+    name: 'office365',
+
+    // Display name of the oauth provider
+    title: 'Office 365',
+
+    getAuthURI: function(tenant) {
+      return 'https://login.microsoftonline.com/' + tenant + '/oauth2/authorize';
+    },
+
+    configureOAuthButton: function(component, settings, state) {
+      var missing = checkMissing(settings);
+
+      if (missing) {
+        component.oauth = {
+          provider: this.name,
+          error: this.title + ' OAuth provider is missing ' + missing
+        };
+      }
+      else {
+        var o365Settings = settings.office365;
+        component.oauth = {
+          provider: this.name,
+          clientId: o365Settings.clientId,
+          authURI: this.getAuthURI(o365Settings.tenant),
+          state: state
+        };
+      }
+    },
+
+    isAvailable: function(settings) {
+      return !checkMissing(settings);
+    },
+
+    // List of field data that can be autofilled from user info API request
+    autofillFields: [
+      {
+        title: 'Email',
+        name: 'Id'
+      },
+      {
+        title: 'Display Name',
+        name: 'DisplayName'
+      }
+    ],
+
+    // Exchanges authentication code for auth token
+    // Returns a promise, or you can provide the next callback arg
+    // Resolves with array of tokens defined like externalTokenSchema
+    getTokens: function(req, code, state, redirectURI, next) {
+      return Q.ninvoke(hook, 'settings', req)
+      .then(function(settings) {
+        var missing = checkMissing(settings);
+        if (missing) {
+          throw {
+            status: 400,
+            message: this.title + ' OAuth provider is missing ' + missing
+          };
+        }
+        var o365Settings = settings.office365;
+        var authContext = new AuthenticationContext('https://login.windows.net/' + o365Settings.tenant);
+        return Q.ninvoke(authContext, 'acquireTokenWithAuthorizationCode',
+          code,
+          redirectURI,
+          'https://outlook.office365.com/',
+          o365Settings.clientId,
+          o365Settings.clientSecret
+        );
+      }.bind(this))
+      .then(function(result) {
+        if (!result) {
+          throw 'No response from Microsoft.';
+        }
+        if (result.error) {
+          throw result.error;
+        }
+        return [
+          {
+            type: this.name,
+            token: result.accessToken,
+            exp: new Date(result.expiresOn)
+          },
+          {
+            type: this.name + '_refresh',
+            token: result.refreshToken,
+            exp: null // Expiration of refresh token is unknown
+          }
+        ];
+      }.bind(this))
+      .nodeify(next);
+    },
+
+    // Gets user information from oauth access token
+    // Returns a promise, or you can provide the next callback arg
+    getUser: function(tokens, next) {
+      var accessToken = _.find(tokens, {type: this.name});
+      if (!accessToken) {
+        return Q.reject('No access token found');
+      }
+      return util.request({
+        method: 'GET',
+        url: 'https://outlook.office.com/api/v1.0/me',
+        json: true,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + accessToken.token,
+          'User-Agent': 'form.io/1.0',
+          'client-request-id': uuid.v4(),
+          'return-client-request-id': true,
+          'Date': (new Date()).toUTCString()
+        }
+      })
+      .spread(function(response, userInfo) {
+        if (!userInfo) {
+          var status = response.statusCode;
+          throw {
+            status: status,
+            message: status + ' response from Microsoft: ' + response.statusMessage
+          };
+        }
+        return userInfo;
+      })
+      .nodeify(next);
+    },
+
+    // Gets user ID from provider user response from getUser()
+    getUserId: function(user) {
+      return user.Id;
+    },
+
+    // Sends a request to refresh tokens and resolves with new tokens
+    // Returns a promise, or you can provide the next callback arg
+    refreshTokens: function(req, res, user, next) {
+      return Q.ninvoke(hook, 'settings', req)
+      .then(function(settings) {
+        if (
+          !settings.office365 ||
+          !settings.office365.tenant ||
+          !settings.office365.clientId ||
+          !settings.office365.clientSecret
+        ) {
+          throw 'Office 365 OAuth settings not configured.';
+        }
+        var refreshToken = _.find(user.externalTokens, {type: 'office365_refresh'});
+        if (!refreshToken) {
+          throw 'No refresh token available. Please reauthenticate with Office 365';
+        }
+
+        var context = new AuthenticationContext('https://login.windows.net/' + settings.office365.tenant);
+        return Q.ninvoke(context, 'acquireTokenWithRefreshToken',
+          refreshToken.token,
+          settings.office365.clientId,
+          settings.office365.clientSecret,
+          null
+        );
+      })
+      .then(function(result) {
+        return [
+          {
+            type: 'office365',
+            token: result.accessToken,
+            exp: new Date(result.expiresOn)
+          },
+          {
+            type: 'office365_refresh',
+            token: result.refreshToken,
+            exp: null // Expiration of refresh token is unknown
+          }
+        ];
+      })
+      .catch(function() {
+        throw 'Token has expired. Please reauthenticate with Office 365';
+      })
+      .nodeify(next);
+    }
+  };
+};

--- a/src/resources/SubmissionResource.js
+++ b/src/resources/SubmissionResource.js
@@ -15,7 +15,7 @@ module.exports = function(router) {
   ];
   handlers.afterPost = [
     handlers.afterPost,
-    router.formio.middleware.filterResourcejsResponse(['deleted', '__v']),
+    router.formio.middleware.filterResourcejsResponse(['deleted', '__v', 'externalTokens']),
     router.formio.middleware.filterProtectedFields
   ];
   handlers.beforeGet = [
@@ -24,7 +24,7 @@ module.exports = function(router) {
   ];
   handlers.afterGet = [
     handlers.afterGet,
-    router.formio.middleware.filterResourcejsResponse(['deleted', '__v']),
+    router.formio.middleware.filterResourcejsResponse(['deleted', '__v', 'externalTokens']),
     router.formio.middleware.filterProtectedFields
   ];
   handlers.beforePut = [
@@ -34,7 +34,7 @@ module.exports = function(router) {
   ];
   handlers.afterPut = [
     handlers.afterPut,
-    router.formio.middleware.filterResourcejsResponse(['deleted', '__v']),
+    router.formio.middleware.filterResourcejsResponse(['deleted', '__v', 'externalTokens']),
     router.formio.middleware.filterProtectedFields
   ];
   handlers.beforeIndex = [
@@ -45,7 +45,7 @@ module.exports = function(router) {
   ];
   handlers.afterIndex = [
     handlers.afterIndex,
-    router.formio.middleware.filterResourcejsResponse(['deleted', '__v']),
+    router.formio.middleware.filterResourcejsResponse(['deleted', '__v', 'externalTokens']),
     router.formio.middleware.filterProtectedFields
   ];
   handlers.beforeDelete = [
@@ -55,7 +55,7 @@ module.exports = function(router) {
   ];
   handlers.afterDelete = [
     handlers.afterDelete,
-    router.formio.middleware.filterResourcejsResponse(['deleted', '__v']),
+    router.formio.middleware.filterResourcejsResponse(['deleted', '__v', 'externalTokens']),
     router.formio.middleware.filterProtectedFields
   ];
 

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -279,5 +279,13 @@ module.exports = {
    */
   getFormComponentKey: function(key) {
     return key.replace(/\.data\./g, '.');
-  }
+  },
+
+  /**
+   * A promisified version of request. Use this if you need
+   * to be able to mock requests for tests, as it's much easier
+   * to mock this than the individual required 'request' modules
+   * in each file.
+   */
+  request: Q.denodeify(require('request'))
 };

--- a/test/config.json
+++ b/test/config.json
@@ -21,7 +21,20 @@
       "test2": {
         "clientId": "TESTCLIENTID2",
         "clientSecret": "TESTCLIENTSECRET2"
+      },
+      "github": {
+        "clientId": "TESTCLIENTIDGITHUB",
+        "clientSecret": "TESTCLIENTSECRETGITHUB"
+      },
+      "facebook": {
+        "clientId": "TESTCLIENTIDFACEBOOK",
+        "clientSecret": "TESTCLIENTSECRETFACEBOOK"
       }
+    },
+    "office365": {
+      "tenant": "testformio.onmicrosoft.com",
+      "clientId": "TESTCLIENTIDOFFICE365",
+      "clientSecret": "TESTCLIENTSECRETOFFICE365"
     }
   }
 }

--- a/test/oauth/facebook.js
+++ b/test/oauth/facebook.js
@@ -1,0 +1,366 @@
+/* eslint-env mocha */
+'use strict';
+
+var request = require('supertest');
+var assert = require('assert');
+var _ = require('lodash');
+var Q = require('q');
+var sinon = require('sinon');
+var util = require('../../src/util/util');
+
+module.exports = function(app, template, hook) {
+  // Cannot run these tests without access to formio instance
+  if (!app.formio) {
+    return;
+  }
+
+  describe('Facebook', function() {
+    var oauthSettings;
+
+    describe('Bootstrap', function() {
+      // Only need a Register form because we can test both registration and
+      // login with it. Everything else is covered by the general oauth tests.
+
+      // Also reusing the oauthUserResource from the general oauth tests
+
+      it('Create a Register Form for OAuth Action tests', function(done) {
+        var facebookOauthRegisterForm = {
+          title: 'Facebook OAuth Register Form',
+          name: 'facebookOauthRegisterForm',
+          path: 'facebookoauthregisterform',
+          type: 'form',
+          access: [],
+          submissionAccess: [],
+          components: [
+            {
+              input: true,
+              type: 'button',
+              theme: 'primary',
+              disableOnInvalid: 'false',
+              action: 'oauth',
+              key: 'facebookSignup',
+              label: 'Sign-Up with Facebook'
+            }
+          ]
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send(facebookOauthRegisterForm)
+          .expect('Content-Type', /json/)
+          .expect(201)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert(response.hasOwnProperty('modified'), 'The response should contain a `modified` timestamp.');
+            assert(response.hasOwnProperty('created'), 'The response should contain a `created` timestamp.');
+            assert(response.hasOwnProperty('access'), 'The response should contain an the `access`.');
+            assert.equal(response.title, facebookOauthRegisterForm.title);
+            assert.equal(response.name, facebookOauthRegisterForm.name);
+            assert.equal(response.path, facebookOauthRegisterForm.path);
+            assert.equal(response.type, 'form');
+            assert.equal(response.access.length, 1);
+            assert.equal(response.access[0].type, 'read_all');
+            assert.equal(response.access[0].roles.length, 3);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.anonymous._id.toString()), -1);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.authenticated._id.toString()), -1);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.administrator._id.toString()), -1);
+            assert.deepEqual(response.submissionAccess, []);
+            assert.deepEqual(response.components, facebookOauthRegisterForm.components);
+            template.forms.facebookOauthRegisterForm = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Set up submission create_own access for Anonymous users for Register Form', function(done) {
+        request(app)
+          .put(hook.alter('url', '/form/' + template.forms.facebookOauthRegisterForm._id, template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send({submissionAccess: [{
+            type: 'create_own',
+            roles: [template.roles.anonymous._id.toString()]
+          }]})
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert.equal(response.submissionAccess[0].type, 'create_own');
+            assert.equal(response.submissionAccess[0].roles.length, 1);
+            assert.equal(response.submissionAccess[0].roles[0], template.roles.anonymous._id.toString());
+
+            // Save this form for later use.
+            template.forms.facebookOauthRegisterForm = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Create OAuthAction for Facebook provider for Register Form', function(done) {
+        var facebookOauthRegisterAction = {
+          title: 'OAuth',
+          name: 'oauth',
+          handler: ['after', 'before'],
+          method: ['form', 'create'],
+          priority: 20,
+          settings: {
+            provider: 'facebook',
+            association: 'new',
+            resource: template.forms.oauthUserResource.name,
+            role: template.roles.authenticated._id.toString(),
+            button: 'facebookSignup',
+            'autofill-facebook-email': 'oauthUser.email'
+          }
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.facebookOauthRegisterForm._id + '/action', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send(facebookOauthRegisterAction)
+          .expect('Content-Type', /json/)
+          .expect(201)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert.equal(response.title, facebookOauthRegisterAction.title);
+            assert.equal(response.name, facebookOauthRegisterAction.name);
+            assert.deepEqual(response.handler, facebookOauthRegisterAction.handler);
+            assert.deepEqual(response.method, facebookOauthRegisterAction.method);
+            assert.equal(response.priority, facebookOauthRegisterAction.priority);
+            assert.deepEqual(response.settings, facebookOauthRegisterAction.settings);
+            assert.equal(response.form, template.forms.facebookOauthRegisterForm._id);
+            facebookOauthRegisterAction = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Get OAuth settings', function(done) {
+        hook.settings(null, function(err, settings) {
+          if (err) {
+            return done(err);
+          }
+          oauthSettings = settings.oauth;
+          assert(oauthSettings.facebook);
+          assert(oauthSettings.facebook.clientId);
+          assert(oauthSettings.facebook.clientSecret);
+          done();
+        });
+      });
+    });
+
+    describe('After Form Handler', function() {
+      it('Should modify a Form Read with ?live=1', function(done) {
+        request(app)
+          .get(hook.alter('url', '/form/' + template.forms.facebookOauthRegisterForm._id + '?live=1', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            response.components = util.flattenComponents(response.components);
+            var flattenedComponents = util.flattenComponents(template.forms.facebookOauthRegisterForm.components);
+            _.each(response.components, function(component, i) {
+              if (component.action === 'oauth') {
+                assert.equal(component.oauth.provider, app.formio.oauth.providers.facebook.name);
+                assert.equal(component.oauth.clientId, oauthSettings.facebook.clientId);
+                assert.equal(component.oauth.authURI, app.formio.oauth.providers.facebook.authURI);
+                assert.equal(component.oauth.scope, app.formio.oauth.providers.facebook.scope);
+                assert.equal(component.oauth.display, app.formio.oauth.providers.facebook.display);
+                assert.deepEqual(_.omit(component, 'oauth'), flattenedComponents[i],
+                  'OAuth button should only have oauth prop added');
+              }
+              else {
+                assert.deepEqual(component, flattenedComponents[i], 'Non oauth buttons should remain unchanged');
+              }
+            });
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+    });
+
+    describe('Facebook OAuth Submission Handler', function() {
+      var TEST_AUTH_CODE = 'TESTAUTHCODE';
+      var TEST_ACCESS_TOKEN = 'TESTACCESSTOKEN';
+      var TEST_REDIRECT_URI = 'http://testuri.com';
+      var TEST_USER = { //id,name,email,first_name,last_name,middle_name
+        id: 123456,
+        name: 'Rahat Ahmed',
+        email: 'rahatarmanahmed@gmail.com',
+        first_name: 'Rahat',
+        last_name: 'Ahmed'
+      };
+
+      beforeEach(function() {
+        // Make the code and token unique for each test
+        TEST_AUTH_CODE = 'TESTAUTHCODE' + Date.now();
+        TEST_ACCESS_TOKEN = 'TESTACCESSTOKEN' + Date.now();
+
+        sinon.stub(util, 'request')
+          .throws(new Error('Request made with unexpected arguments'))
+
+          .withArgs(sinon.match({
+            url: 'https://graph.facebook.com/v2.3/oauth/access_token',
+            body: sinon.match({
+              client_id: oauthSettings.facebook.clientId,
+              client_secret: oauthSettings.facebook.clientSecret,
+              code: TEST_AUTH_CODE
+            })
+          }))
+          .returns(Q([
+            {
+              headers: {
+                date: new Date()
+              }
+            },
+            {
+              access_token: TEST_ACCESS_TOKEN,
+              expires_in: 86400
+            }
+          ]))
+
+          .withArgs(sinon.match({
+            url: 'https://graph.facebook.com/v2.3/me',
+            qs: sinon.match({
+              access_token: TEST_ACCESS_TOKEN
+            })
+          }))
+          .returns(Q([{}, TEST_USER]))
+      });
+
+      afterEach(function() {
+        util.request.restore();
+      });
+
+      it('An anonymous user should be able to register with OAuth provider Facebook', function(done) {
+        var submission = {
+          data: {},
+          oauth: {
+            facebook: {
+              code: TEST_AUTH_CODE,
+              state: 'teststate', // Scope only matters for client side validation
+              redirectURI: TEST_REDIRECT_URI
+            }
+          }
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.facebookOauthRegisterForm._id + '/submission', template))
+          .send(submission)
+          .expect(200)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert(response.hasOwnProperty('modified'), 'The response should contain a `modified` timestamp.');
+            assert(response.hasOwnProperty('created'), 'The response should contain a `created` timestamp.');
+            assert(response.hasOwnProperty('data'), 'The response should contain a submission `data` object.');
+            assert.equal(response.data.email, TEST_USER.email, 'The OAuth Action should autofill the email field.');
+            assert.equal(response.form, template.forms.oauthUserResource._id, 'The submission returned should be for the authenticated resource.');
+            assert(response.hasOwnProperty('roles'), 'The response should contain the resource `roles`.');
+            assert.deepEqual(response.roles, [template.roles.authenticated._id.toString()], 'The submission should have the OAuth Action configured role added to it.');
+            assert.equal(response.externalIds.length, 1);
+            assert(response.externalIds[0].hasOwnProperty('_id'), 'The externalId should contain an `_id`.');
+            assert(response.externalIds[0].hasOwnProperty('modified'), 'The externalId should contain a `modified` timestamp.');
+            assert(response.externalIds[0].hasOwnProperty('created'), 'The externalId should contain a `created` timestamp.');
+            assert.equal(response.externalIds[0].type, app.formio.oauth.providers.facebook.name, 'The externalId should be for facebook oauth.');
+            assert.equal(response.externalIds[0].id, TEST_USER.id, 'The externalId should match test user 1\'s id.');
+            assert(!response.hasOwnProperty('externalTokens'), 'The response should not contain `externalTokens`');
+            assert(!response.hasOwnProperty('deleted'), 'The response should not contain `deleted`');
+            assert(!response.hasOwnProperty('__v'), 'The response should not contain `__v`');
+            assert(res.headers.hasOwnProperty('x-jwt-token'), 'The response should contain a `x-jwt-token` header.');
+            assert(response.hasOwnProperty('owner'), 'The response should contain the resource `owner`.');
+            assert.notEqual(response.owner, null);
+            assert.equal(response.owner, response._id);
+
+            // Save user for later tests
+            template.users.facebookOauthUser = response;
+            template.users.facebookOauthUser.token = res.headers['x-jwt-token'];
+            done();
+        });
+      });
+
+      it('An anonymous user should be logged in when registering with a previously registered OAuth provider Facebook account', function(done) {
+        var submission = {
+          data: {},
+          oauth: {
+            facebook: {
+              code: TEST_AUTH_CODE,
+              state: 'teststate', // Scope only matters for client side validation
+              redirectURI: TEST_REDIRECT_URI
+            }
+          }
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.facebookOauthRegisterForm._id + '/submission', template))
+          .send(submission)
+          .expect(200)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert(response.hasOwnProperty('modified'), 'The response should contain a `modified` timestamp.');
+            assert(response.hasOwnProperty('created'), 'The response should contain a `created` timestamp.');
+            assert(response.hasOwnProperty('data'), 'The response should contain a submission `data` object.');
+            assert.equal(response.data.email, TEST_USER.email, 'The OAuth Action should return a user with the right email.');
+            assert.equal(response.form, template.forms.oauthUserResource._id, 'The submission returned should be for the authenticated resource.');
+            assert(response.hasOwnProperty('roles'), 'The response should contain the resource `roles`.');
+            assert.deepEqual(response.roles, [template.roles.authenticated._id.toString()], 'The submission should have the OAuth Action configured role.');
+            assert.equal(response.externalIds.length, 1);
+            assert(response.externalIds[0].hasOwnProperty('_id'), 'The externalId should contain an `_id`.');
+            assert(response.externalIds[0].hasOwnProperty('modified'), 'The externalId should contain a `modified` timestamp.');
+            assert(response.externalIds[0].hasOwnProperty('created'), 'The externalId should contain a `created` timestamp.');
+            assert.equal(response.externalIds[0].type, app.formio.oauth.providers.facebook.name, 'The externalId should be for facebook oauth.');
+            assert.equal(response.externalIds[0].id, TEST_USER.id, 'The externalId should match test user 1\'s id.');
+            assert(!response.hasOwnProperty('externalTokens'), 'The response should not contain `externalTokens`');
+            assert(!response.hasOwnProperty('deleted'), 'The response should not contain `deleted`');
+            assert(!response.hasOwnProperty('__v'), 'The response should not contain `__v`');
+            assert(res.headers.hasOwnProperty('x-jwt-token'), 'The response should contain a `x-jwt-token` header.');
+            assert(response.hasOwnProperty('owner'), 'The response should contain the resource `owner`.');
+            assert.notEqual(response.owner, null);
+            assert.equal(response.owner, response._id);
+
+            done();
+          });
+      });
+    });
+  });
+};

--- a/test/oauth/github.js
+++ b/test/oauth/github.js
@@ -1,0 +1,370 @@
+/* eslint-env mocha */
+'use strict';
+
+var request = require('supertest');
+var assert = require('assert');
+var _ = require('lodash');
+var Q = require('q');
+var sinon = require('sinon');
+var util = require('../../src/util/util');
+
+module.exports = function(app, template, hook) {
+  // Cannot run these tests without access to formio instance
+  if (!app.formio) {
+    return;
+  }
+
+  describe('GitHub', function() {
+    var oauthSettings;
+
+    describe('Bootstrap', function() {
+      // Only need a Register form because we can test both registration and
+      // login with it. Everything else is covered by the general oauth tests.
+
+      // Also reusing the oauthUserResource from the general oauth tests
+
+      it('Create a Register Form for OAuth Action tests', function(done) {
+        var githubOauthRegisterForm = {
+          title: 'GitHub OAuth Register Form',
+          name: 'githubOauthRegisterForm',
+          path: 'githuboauthregisterform',
+          type: 'form',
+          access: [],
+          submissionAccess: [],
+          components: [
+            {
+              input: true,
+              type: 'button',
+              theme: 'primary',
+              disableOnInvalid: 'false',
+              action: 'oauth',
+              key: 'githubSignup',
+              label: 'Sign-Up with Github'
+            }
+          ]
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send(githubOauthRegisterForm)
+          .expect('Content-Type', /json/)
+          .expect(201)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert(response.hasOwnProperty('modified'), 'The response should contain a `modified` timestamp.');
+            assert(response.hasOwnProperty('created'), 'The response should contain a `created` timestamp.');
+            assert(response.hasOwnProperty('access'), 'The response should contain an the `access`.');
+            assert.equal(response.title, githubOauthRegisterForm.title);
+            assert.equal(response.name, githubOauthRegisterForm.name);
+            assert.equal(response.path, githubOauthRegisterForm.path);
+            assert.equal(response.type, 'form');
+            assert.equal(response.access.length, 1);
+            assert.equal(response.access[0].type, 'read_all');
+            assert.equal(response.access[0].roles.length, 3);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.anonymous._id.toString()), -1);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.authenticated._id.toString()), -1);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.administrator._id.toString()), -1);
+            assert.deepEqual(response.submissionAccess, []);
+            assert.deepEqual(response.components, githubOauthRegisterForm.components);
+            template.forms.githubOauthRegisterForm = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Set up submission create_own access for Anonymous users for Register Form', function(done) {
+        request(app)
+          .put(hook.alter('url', '/form/' + template.forms.githubOauthRegisterForm._id, template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send({submissionAccess: [{
+            type: 'create_own',
+            roles: [template.roles.anonymous._id.toString()]
+          }]})
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert.equal(response.submissionAccess[0].type, 'create_own');
+            assert.equal(response.submissionAccess[0].roles.length, 1);
+            assert.equal(response.submissionAccess[0].roles[0], template.roles.anonymous._id.toString());
+
+            // Save this form for later use.
+            template.forms.githubOauthRegisterForm = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Create OAuthAction for GitHub provider for Register Form', function(done) {
+        var githubOauthRegisterAction = {
+          title: 'OAuth',
+          name: 'oauth',
+          handler: ['after', 'before'],
+          method: ['form', 'create'],
+          priority: 20,
+          settings: {
+            provider: 'github',
+            association: 'new',
+            resource: template.forms.oauthUserResource.name,
+            role: template.roles.authenticated._id.toString(),
+            button: 'githubSignup',
+            'autofill-github-email': 'oauthUser.email'
+          }
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.githubOauthRegisterForm._id + '/action', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send(githubOauthRegisterAction)
+          .expect('Content-Type', /json/)
+          .expect(201)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert.equal(response.title, githubOauthRegisterAction.title);
+            assert.equal(response.name, githubOauthRegisterAction.name);
+            assert.deepEqual(response.handler, githubOauthRegisterAction.handler);
+            assert.deepEqual(response.method, githubOauthRegisterAction.method);
+            assert.equal(response.priority, githubOauthRegisterAction.priority);
+            assert.deepEqual(response.settings, githubOauthRegisterAction.settings);
+            assert.equal(response.form, template.forms.githubOauthRegisterForm._id);
+            githubOauthRegisterAction = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Get OAuth settings', function(done) {
+        hook.settings(null, function(err, settings) {
+          if (err) {
+            return done(err);
+          }
+          oauthSettings = settings.oauth;
+          assert(oauthSettings.github);
+          assert(oauthSettings.github.clientId);
+          assert(oauthSettings.github.clientSecret);
+          done();
+        });
+      });
+    });
+
+    describe('After Form Handler', function() {
+      it('Should modify a Form Read with ?live=1', function(done) {
+        request(app)
+          .get(hook.alter('url', '/form/' + template.forms.githubOauthRegisterForm._id + '?live=1', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            response.components = util.flattenComponents(response.components);
+            var flattenedComponents = util.flattenComponents(template.forms.githubOauthRegisterForm.components);
+            _.each(response.components, function(component, i) {
+              if (component.action === 'oauth') {
+                assert.equal(component.oauth.provider, app.formio.oauth.providers.github.name);
+                assert.equal(component.oauth.clientId, oauthSettings.github.clientId);
+                assert.equal(component.oauth.authURI, app.formio.oauth.providers.github.authURI);
+                assert.equal(component.oauth.scope, app.formio.oauth.providers.github.scope);
+                assert.equal(component.oauth.display, app.formio.oauth.providers.github.display);
+                assert.deepEqual(_.omit(component, 'oauth'), flattenedComponents[i],
+                  'OAuth button should only have oauth prop added');
+              }
+              else {
+                assert.deepEqual(component, flattenedComponents[i], 'Non oauth buttons should remain unchanged');
+              }
+            });
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+    });
+
+    describe('Github OAuth Submission Handler', function() {
+      var TEST_AUTH_CODE = 'TESTAUTHCODE';
+      var TEST_ACCESS_TOKEN = 'TESTACCESSTOKEN';
+      var TEST_REDIRECT_URI = 'http://testuri.com';
+      var TEST_USER = {
+        login: 'rahatarmanahmed',
+        id: 123456,
+        name: 'Rahat Ahmed',
+        email: null // Test with private emails requiring another request
+      };
+
+      var TEST_EMAIL_RESPONSE = [
+        {
+          primary: true,
+          verified: true,
+          email: 'rahatarmanahmed@gmail.com'
+        }
+      ];
+
+      beforeEach(function() {
+        // Make the code and token unique for each test
+        TEST_AUTH_CODE = 'TESTAUTHCODE' + Date.now();
+        TEST_ACCESS_TOKEN = 'TESTACCESSTOKEN' + Date.now();
+
+        sinon.stub(util, 'request')
+          .throws(new Error('Request made with unexpected arguments'))
+
+          .withArgs(sinon.match({
+            url: 'https://github.com/login/oauth/access_token',
+            body: sinon.match({
+              client_id: oauthSettings.github.clientId,
+              client_secret: oauthSettings.github.clientSecret,
+              code: TEST_AUTH_CODE
+            })
+          }))
+          .returns(Q([{},
+            {
+              access_token: TEST_ACCESS_TOKEN
+            }
+          ]))
+
+          .withArgs(sinon.match({
+            url: 'https://api.github.com/user',
+            headers: sinon.match({
+              Authorization: 'token ' + TEST_ACCESS_TOKEN
+            })
+          }))
+          .returns(Q([{}, TEST_USER]))
+
+          .withArgs(sinon.match({url: 'https://api.github.com/user/emails'}))
+          .returns(Q([{}, TEST_EMAIL_RESPONSE]));
+      });
+
+      afterEach(function() {
+        util.request.restore();
+      });
+
+      it('An anonymous user should be able to register with OAuth provider GitHub', function(done) {
+        var submission = {
+          data: {},
+          oauth: {
+            github: {
+              code: TEST_AUTH_CODE,
+              state: 'teststate', // Scope only matters for client side validation
+              redirectURI: TEST_REDIRECT_URI
+            }
+          }
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.githubOauthRegisterForm._id + '/submission', template))
+          .send(submission)
+          .expect(200)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert(response.hasOwnProperty('modified'), 'The response should contain a `modified` timestamp.');
+            assert(response.hasOwnProperty('created'), 'The response should contain a `created` timestamp.');
+            assert(response.hasOwnProperty('data'), 'The response should contain a submission `data` object.');
+            assert.equal(response.data.email, TEST_EMAIL_RESPONSE[0].email, 'The OAuth Action should autofill the email field.');
+            assert.equal(response.form, template.forms.oauthUserResource._id, 'The submission returned should be for the authenticated resource.');
+            assert(response.hasOwnProperty('roles'), 'The response should contain the resource `roles`.');
+            assert.deepEqual(response.roles, [template.roles.authenticated._id.toString()], 'The submission should have the OAuth Action configured role added to it.');
+            assert.equal(response.externalIds.length, 1);
+            assert(response.externalIds[0].hasOwnProperty('_id'), 'The externalId should contain an `_id`.');
+            assert(response.externalIds[0].hasOwnProperty('modified'), 'The externalId should contain a `modified` timestamp.');
+            assert(response.externalIds[0].hasOwnProperty('created'), 'The externalId should contain a `created` timestamp.');
+            assert.equal(response.externalIds[0].type, app.formio.oauth.providers.github.name, 'The externalId should be for github oauth.');
+            assert.equal(response.externalIds[0].id, TEST_USER.id, 'The externalId should match test user 1\'s id.');
+            assert(!response.hasOwnProperty('externalTokens'), 'The response should not contain `externalTokens`');
+            assert(!response.hasOwnProperty('deleted'), 'The response should not contain `deleted`');
+            assert(!response.hasOwnProperty('__v'), 'The response should not contain `__v`');
+            assert(res.headers.hasOwnProperty('x-jwt-token'), 'The response should contain a `x-jwt-token` header.');
+            assert(response.hasOwnProperty('owner'), 'The response should contain the resource `owner`.');
+            assert.notEqual(response.owner, null);
+            assert.equal(response.owner, response._id);
+
+            // Save user for later tests
+            template.users.githubOauthUser = response;
+            template.users.githubOauthUser.token = res.headers['x-jwt-token'];
+            done();
+        });
+      });
+
+      it('An anonymous user should be logged in when registering with a previously registered OAuth provider GitHub account', function(done) {
+        var submission = {
+          data: {},
+          oauth: {
+            github: {
+              code: TEST_AUTH_CODE,
+              state: 'teststate', // Scope only matters for client side validation
+              redirectURI: TEST_REDIRECT_URI
+            }
+          }
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.githubOauthRegisterForm._id + '/submission', template))
+          .send(submission)
+          .expect(200)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert(response.hasOwnProperty('modified'), 'The response should contain a `modified` timestamp.');
+            assert(response.hasOwnProperty('created'), 'The response should contain a `created` timestamp.');
+            assert(response.hasOwnProperty('data'), 'The response should contain a submission `data` object.');
+            assert.equal(response.data.email, TEST_EMAIL_RESPONSE[0].email, 'The OAuth Action should return a user with the right email.');
+            assert.equal(response.form, template.forms.oauthUserResource._id, 'The submission returned should be for the authenticated resource.');
+            assert(response.hasOwnProperty('roles'), 'The response should contain the resource `roles`.');
+            assert.deepEqual(response.roles, [template.roles.authenticated._id.toString()], 'The submission should have the OAuth Action configured role.');
+            assert.equal(response.externalIds.length, 1);
+            assert(response.externalIds[0].hasOwnProperty('_id'), 'The externalId should contain an `_id`.');
+            assert(response.externalIds[0].hasOwnProperty('modified'), 'The externalId should contain a `modified` timestamp.');
+            assert(response.externalIds[0].hasOwnProperty('created'), 'The externalId should contain a `created` timestamp.');
+            assert.equal(response.externalIds[0].type, app.formio.oauth.providers.github.name, 'The externalId should be for github oauth.');
+            assert.equal(response.externalIds[0].id, TEST_USER.id, 'The externalId should match test user 1\'s id.');
+            assert(!response.hasOwnProperty('externalTokens'), 'The response should not contain `externalTokens`');
+            assert(!response.hasOwnProperty('deleted'), 'The response should not contain `deleted`');
+            assert(!response.hasOwnProperty('__v'), 'The response should not contain `__v`');
+            assert(res.headers.hasOwnProperty('x-jwt-token'), 'The response should contain a `x-jwt-token` header.');
+            assert(response.hasOwnProperty('owner'), 'The response should contain the resource `owner`.');
+            assert.notEqual(response.owner, null);
+            assert.equal(response.owner, response._id);
+
+            done();
+          });
+      });
+    });
+  });
+};

--- a/test/oauth/office365.js
+++ b/test/oauth/office365.js
@@ -1,0 +1,369 @@
+/* eslint-env mocha */
+'use strict';
+
+var request = require('supertest');
+var assert = require('assert');
+var _ = require('lodash');
+var Q = require('q');
+var AuthenticationContext = require('adal-node').AuthenticationContext;
+var sinon = require('sinon');
+var util = require('../../src/util/util');
+
+module.exports = function(app, template, hook) {
+  // Cannot run these tests without access to formio instance
+  if (!app.formio) {
+    return;
+  }
+
+  describe('Office 365', function() {
+    var office365Settings;
+
+    describe('Bootstrap', function() {
+      // Only need a Register form because we can test both registration and
+      // login with it. Everything else is covered by the general oauth tests.
+
+      // Also reusing the oauthUserResource from the general oauth tests
+
+      it('Create a Register Form for OAuth Action tests', function(done) {
+        var office365OauthRegisterForm = {
+          title: 'Office 365 OAuth Register Form',
+          name: 'office365OauthRegisterForm',
+          path: 'office365oauthregisterform',
+          type: 'form',
+          access: [],
+          submissionAccess: [],
+          components: [
+            {
+              input: true,
+              type: 'button',
+              theme: 'primary',
+              disableOnInvalid: 'false',
+              action: 'oauth',
+              key: 'office365Signup',
+              label: 'Sign-Up with Office 365'
+            }
+          ]
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send(office365OauthRegisterForm)
+          .expect('Content-Type', /json/)
+          .expect(201)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert(response.hasOwnProperty('modified'), 'The response should contain a `modified` timestamp.');
+            assert(response.hasOwnProperty('created'), 'The response should contain a `created` timestamp.');
+            assert(response.hasOwnProperty('access'), 'The response should contain an the `access`.');
+            assert.equal(response.title, office365OauthRegisterForm.title);
+            assert.equal(response.name, office365OauthRegisterForm.name);
+            assert.equal(response.path, office365OauthRegisterForm.path);
+            assert.equal(response.type, 'form');
+            assert.equal(response.access.length, 1);
+            assert.equal(response.access[0].type, 'read_all');
+            assert.equal(response.access[0].roles.length, 3);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.anonymous._id.toString()), -1);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.authenticated._id.toString()), -1);
+            assert.notEqual(response.access[0].roles.indexOf(template.roles.administrator._id.toString()), -1);
+            assert.deepEqual(response.submissionAccess, []);
+            assert.deepEqual(response.components, office365OauthRegisterForm.components);
+            template.forms.office365OauthRegisterForm = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Set up submission create_own access for Anonymous users for Register Form', function(done) {
+        request(app)
+          .put(hook.alter('url', '/form/' + template.forms.office365OauthRegisterForm._id, template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send({submissionAccess: [{
+            type: 'create_own',
+            roles: [template.roles.anonymous._id.toString()]
+          }]})
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert.equal(response.submissionAccess[0].type, 'create_own');
+            assert.equal(response.submissionAccess[0].roles.length, 1);
+            assert.equal(response.submissionAccess[0].roles[0], template.roles.anonymous._id.toString());
+
+            // Save this form for later use.
+            template.forms.office365OauthRegisterForm = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Create OAuthAction for Office 365 provider for Register Form', function(done) {
+        var office365OauthRegisterAction = {
+          title: 'OAuth',
+          name: 'oauth',
+          handler: ['after', 'before'],
+          method: ['form', 'create'],
+          priority: 20,
+          settings: {
+            provider: 'office365',
+            association: 'new',
+            resource: template.forms.oauthUserResource.name,
+            role: template.roles.authenticated._id.toString(),
+            button: 'office365Signup',
+            'autofill-office365-Id': 'oauthUser.email'
+          }
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.office365OauthRegisterForm._id + '/action', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send(office365OauthRegisterAction)
+          .expect('Content-Type', /json/)
+          .expect(201)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert.equal(response.title, office365OauthRegisterAction.title);
+            assert.equal(response.name, office365OauthRegisterAction.name);
+            assert.deepEqual(response.handler, office365OauthRegisterAction.handler);
+            assert.deepEqual(response.method, office365OauthRegisterAction.method);
+            assert.equal(response.priority, office365OauthRegisterAction.priority);
+            assert.deepEqual(response.settings, office365OauthRegisterAction.settings);
+            assert.equal(response.form, template.forms.office365OauthRegisterForm._id);
+            office365OauthRegisterAction = response;
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+
+      it('Get OAuth settings', function(done) {
+        hook.settings(null, function(err, settings) {
+          if (err) {
+            return done(err);
+          }
+          office365Settings = settings.office365;
+          assert(office365Settings);
+          assert(office365Settings.tenant);
+          assert(office365Settings.clientId);
+          assert(office365Settings.clientSecret);
+          done();
+        });
+      });
+    });
+
+    describe('After Form Handler', function() {
+      it('Should modify a Form Read with ?live=1', function(done) {
+        request(app)
+          .get(hook.alter('url', '/form/' + template.forms.office365OauthRegisterForm._id + '?live=1', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            response.components = util.flattenComponents(response.components);
+            var flattenedComponents = util.flattenComponents(template.forms.office365OauthRegisterForm.components);
+            _.each(response.components, function(component, i) {
+              if (component.action === 'oauth') {
+                assert.equal(component.oauth.provider, app.formio.oauth.providers.office365.name);
+                assert.equal(component.oauth.clientId, office365Settings.clientId);
+                assert.equal(component.oauth.authURI, app.formio.oauth.providers.office365.getAuthURI(office365Settings.tenant));
+                assert.equal(component.oauth.scope, app.formio.oauth.providers.office365.scope);
+                assert.equal(component.oauth.display, app.formio.oauth.providers.office365.display);
+                assert.deepEqual(_.omit(component, 'oauth'), flattenedComponents[i],
+                  'OAuth button should only have oauth prop added');
+              }
+              else {
+                assert.deepEqual(component, flattenedComponents[i], 'Non oauth buttons should remain unchanged');
+              }
+            });
+
+            // Store the JWT for future API calls.
+            template.users.admin.token = res.headers['x-jwt-token'];
+
+            done();
+          });
+      });
+    });
+
+    describe('Office 365 OAuth Submission Handler', function() {
+      var TEST_AUTH_CODE = 'TESTAUTHCODE';
+      var TEST_ACCESS_TOKEN = 'TESTACCESSTOKEN';
+      var TEST_REFRESH_TOKEN = 'TESTREFRESHTOKEN';
+      var TEST_REDIRECT_URI = 'http://testuri.com';
+      var TEST_USER = {
+        Id: 'rahatarmanahmed@gmail.com',
+        DisplayName: 'Rahat Ahmed'
+      };
+
+      var TEST_EMAIL_RESPONSE = [
+        {
+          primary: true,
+          verified: true,
+          email: 'rahatarmanahmed@gmail.com'
+        }
+      ];
+
+      beforeEach(function() {
+        // Make the code and token unique for each test
+        TEST_AUTH_CODE = 'TESTAUTHCODE' + Date.now();
+        TEST_ACCESS_TOKEN = 'TESTACCESSTOKEN' + Date.now();
+        TEST_REFRESH_TOKEN = 'TESTREFRESHTOKEN' + Date.now();
+
+        sinon.stub(AuthenticationContext.prototype, 'acquireTokenWithAuthorizationCode')
+        .withArgs(
+          TEST_AUTH_CODE,
+          TEST_REDIRECT_URI,
+          'https://outlook.office365.com/',
+          office365Settings.clientId,
+          office365Settings.clientSecret,
+          sinon.match.func)
+        .yields(null, {
+          accessToken: TEST_ACCESS_TOKEN,
+          expiresOn: new Date(Date.now() + 3600000),
+          refreshToken: TEST_REFRESH_TOKEN
+        });
+
+        sinon.stub(util, 'request')
+          .throws(new Error('Request made with unexpected arguments'))
+          .withArgs(sinon.match({
+            url: 'https://outlook.office.com/api/v1.0/me',
+            headers: sinon.match({
+              Authorization: 'Bearer ' + TEST_ACCESS_TOKEN
+            })
+          }))
+          .returns(Q([{}, TEST_USER]));
+      });
+
+      afterEach(function() {
+        util.request.restore();
+        AuthenticationContext.prototype.acquireTokenWithAuthorizationCode.restore();
+      });
+
+      it('An anonymous user should be able to register with OAuth provider Office 365', function(done) {
+        var submission = {
+          data: {},
+          oauth: {
+            office365: {
+              code: TEST_AUTH_CODE,
+              state: 'teststate', // Scope only matters for client side validation
+              redirectURI: TEST_REDIRECT_URI
+            }
+          }
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.office365OauthRegisterForm._id + '/submission', template))
+          .send(submission)
+          .expect(200)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert(response.hasOwnProperty('modified'), 'The response should contain a `modified` timestamp.');
+            assert(response.hasOwnProperty('created'), 'The response should contain a `created` timestamp.');
+            assert(response.hasOwnProperty('data'), 'The response should contain a submission `data` object.');
+            assert.equal(response.data.email, TEST_USER.Id, 'The OAuth Action should autofill the email field.');
+            assert.equal(response.form, template.forms.oauthUserResource._id, 'The submission returned should be for the authenticated resource.');
+            assert(response.hasOwnProperty('roles'), 'The response should contain the resource `roles`.');
+            assert.deepEqual(response.roles, [template.roles.authenticated._id.toString()], 'The submission should have the OAuth Action configured role added to it.');
+            assert.equal(response.externalIds.length, 1);
+            assert(response.externalIds[0].hasOwnProperty('_id'), 'The externalId should contain an `_id`.');
+            assert(response.externalIds[0].hasOwnProperty('modified'), 'The externalId should contain a `modified` timestamp.');
+            assert(response.externalIds[0].hasOwnProperty('created'), 'The externalId should contain a `created` timestamp.');
+            assert.equal(response.externalIds[0].type, app.formio.oauth.providers.office365.name, 'The externalId should be for office365 oauth.');
+            assert.equal(response.externalIds[0].id, TEST_USER.Id, 'The externalId should match test user 1\'s id.');
+            assert(!response.hasOwnProperty('externalTokens'), 'The response should not contain `externalTokens`');
+            assert(!response.hasOwnProperty('deleted'), 'The response should not contain `deleted`');
+            assert(!response.hasOwnProperty('__v'), 'The response should not contain `__v`');
+            assert(res.headers.hasOwnProperty('x-jwt-token'), 'The response should contain a `x-jwt-token` header.');
+            assert(response.hasOwnProperty('owner'), 'The response should contain the resource `owner`.');
+            assert.notEqual(response.owner, null);
+            assert.equal(response.owner, response._id);
+
+            // Save user for later tests
+            template.users.office365OauthUser = response;
+            template.users.office365OauthUser.token = res.headers['x-jwt-token'];
+            done();
+        });
+      });
+
+      it('An anonymous user should be logged in when registering with a previously registered OAuth provider Office 365 account', function(done) {
+        var submission = {
+          data: {},
+          oauth: {
+            office365: {
+              code: TEST_AUTH_CODE,
+              state: 'teststate', // Scope only matters for client side validation
+              redirectURI: TEST_REDIRECT_URI
+            }
+          }
+        };
+
+        request(app)
+          .post(hook.alter('url', '/form/' + template.forms.office365OauthRegisterForm._id + '/submission', template))
+          .send(submission)
+          .expect(200)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var response = res.body;
+            assert(response.hasOwnProperty('_id'), 'The response should contain an `_id`.');
+            assert(response.hasOwnProperty('modified'), 'The response should contain a `modified` timestamp.');
+            assert(response.hasOwnProperty('created'), 'The response should contain a `created` timestamp.');
+            assert(response.hasOwnProperty('data'), 'The response should contain a submission `data` object.');
+            assert.equal(response.data.email, TEST_USER.Id, 'The OAuth Action should return a user with the right email.');
+            assert.equal(response.form, template.forms.oauthUserResource._id, 'The submission returned should be for the authenticated resource.');
+            assert(response.hasOwnProperty('roles'), 'The response should contain the resource `roles`.');
+            assert.deepEqual(response.roles, [template.roles.authenticated._id.toString()], 'The submission should have the OAuth Action configured role.');
+            assert.equal(response.externalIds.length, 1);
+            assert(response.externalIds[0].hasOwnProperty('_id'), 'The externalId should contain an `_id`.');
+            assert(response.externalIds[0].hasOwnProperty('modified'), 'The externalId should contain a `modified` timestamp.');
+            assert(response.externalIds[0].hasOwnProperty('created'), 'The externalId should contain a `created` timestamp.');
+            assert.equal(response.externalIds[0].type, app.formio.oauth.providers.office365.name, 'The externalId should be for office365 oauth.');
+            assert.equal(response.externalIds[0].id, TEST_USER.Id, 'The externalId should match test user 1\'s id.');
+            assert(!response.hasOwnProperty('externalTokens'), 'The response should not contain `externalTokens`');
+            assert(!response.hasOwnProperty('deleted'), 'The response should not contain `deleted`');
+            assert(!response.hasOwnProperty('__v'), 'The response should not contain `__v`');
+            assert(res.headers.hasOwnProperty('x-jwt-token'), 'The response should contain a `x-jwt-token` header.');
+            assert(response.hasOwnProperty('owner'), 'The response should contain the resource `owner`.');
+            assert.notEqual(response.owner, null);
+            assert.equal(response.owner, response._id);
+
+            done();
+          });
+      });
+    });
+  });
+};


### PR DESCRIPTION
 - Office 365 is now an option for OAuth authentication
 - Tokens obtained from OAuth authentication are now stored in the `externalTokens` field of a Submission. This is not returned via API, however
 - Some refactoring to accomodate Office 365's different OAuth approaches.
 - Added mechanism to retrieve a user's token and attempt to refresh it if necessary (`formio.oauth.getUserToken()`)
 - Added more tests for testing individual oauth providers
 - Added tests to check externalTokens