### PR TITLE
Added eslint-config-formio to .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,36 +1,6 @@
 {
+  "extends": "formio",
   "env": {
     "node": true
   },
-  "rules": {
-    "block-scoped-var": 2,
-    "brace-style": [2, "stroustrup", { "allowSingleLine": false }],
-    "camelcase": 1,
-    "curly": 2,
-    "eol-last": 2,
-    "eqeqeq": [2, "smart"],
-    "max-depth": [1, 3],
-    "max-statements": [1, 25],
-    "max-len": [1, 120],
-    "new-cap": [
-      2, 
-      {
-        newIsCap: true, 
-        capIsNew: true, 
-        newIsCapExceptions: [], 
-        capIsNewExceptions: ["Router", "Resource", "Schema", "ObjectId"]
-      }
-    ],
-    "no-extend-native": 2,
-    "no-mixed-spaces-and-tabs": 2,
-    "no-trailing-spaces": 2,
-    "no-use-before-define": [2, "nofunc"],
-    "no-unused-vars": 1,
-    "quotes": [2, "single", "avoid-escape"],
-    "semi": [2, "always"],
-    "space-after-keywords": [2, "always"],
-    "space-in-brackets": [2, "never"],
-    "space-unary-ops": 2,
-    "no-underscore-dangle": 0
-  }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "env TEST_SUITE=1 mocha -r jscoverage --covout=html test/test.js -b -t 60000",
     "start": "node server.js",
-    "lint": "eslint src"
+    "lint": "eslint src *.js"
   },
   "author": "support@form.io",
   "schema": "2.4.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "env TEST_SUITE=1 mocha -r jscoverage --covout=html test/test.js -b -t 60000",
-    "start": "node server.js"
+    "start": "node server.js",
+    "lint": "eslint src"
   },
   "author": "support@form.io",
   "schema": "2.4.3",
@@ -60,7 +61,8 @@
   },
   "devDependencies": {
     "chance": "^0.8.0",
-    "eslint": "^0.20.0",
+    "eslint": "^1.9.0",
+    "eslint-config-formio": "0.0.0",
     "jscoverage": "^0.6.0",
     "mocha": "^2.2.1",
     "sinon": "^1.17.2",


### PR DESCRIPTION
For now, run eslint with `npm run lint`. Should later be added to the npm test script when we have lint errors under control.