### PR TITLE
FA-679 - Updating permission handler to allow users with update_all s…

### DIFF
--- a/src/middleware/permissionHandler.js
+++ b/src/middleware/permissionHandler.js
@@ -75,9 +75,21 @@ module.exports = function(router) {
                 // Define this access type.
                 access.submission[permission.type] = access.submission[permission.type] || [];
 
+                // If the user has update_all permissions, give them create_all access also, to compensate for the
+                // hidden availability of create_all in the formio ui.
+                if (permission.type === 'update_all') {
+                  access.submission.create_all = access.submission.create_all || [];
+                }
+
                 permission.roles.forEach(function(id) {
                   // Add each roleId to the role array for this access type.
                   access.submission[permission.type].push(id.toString());
+
+                  // If the user has update_all permissions, give them create_all access also, to compensate for the
+                  // hidden availability of create_all in the formio ui.
+                  if (permission.type === 'update_all') {
+                    access.submission.create_all.push(id.toString());
+                  }
                 });
               });
             }

--- a/src/middleware/permissionHandler.js
+++ b/src/middleware/permissionHandler.js
@@ -78,7 +78,7 @@ module.exports = function(router) {
                 // If the user has update_all permissions, give them create_all access also, to compensate for the
                 // hidden availability of create_all in the formio ui.
                 if (permission.type === 'update_all') {
-                  access.submission.create_all = access.submission.create_all || [];
+                  access.submission.create_all = access.submission.create_all || []; //eslint-disable-line camelcase
                 }
 
                 permission.roles.forEach(function(id) {
@@ -88,7 +88,7 @@ module.exports = function(router) {
                   // If the user has update_all permissions, give them create_all access also, to compensate for the
                   // hidden availability of create_all in the formio ui.
                   if (permission.type === 'update_all') {
-                    access.submission.create_all.push(id.toString());
+                    access.submission.create_all.push(id.toString()); //eslint-disable-line camelcase
                   }
                 });
               });


### PR DESCRIPTION
…ubmission access to have create_all submission access. This is to ease the disjointness of not being able to set create_all permissions via the ui. Adding tests.