### PR TITLE
FA-620 Fix nested resources crashing on import

### DIFF
--- a/test/template.js
+++ b/test/template.js
@@ -83,6 +83,69 @@ module.exports = function() {
     }
   };
 
+  // Create some circularly dependent resources to make sure
+  // importing this doesn't crash
+  template.resources.a = {
+    title: 'A',
+    type: 'resource',
+    name: 'a',
+    path: 'a',
+    components: [
+      {
+        input: true,
+        tableView: true,
+        label: 'B',
+        key: 'b',
+        placeholder: 'B',
+        resource: 'b',
+        defaultValue: '',
+        template: '<span>{{ item.data }}</span>',
+        selectFields: '',
+        searchFields: '',
+        multiple: false,
+        protected: false,
+        persistent: true,
+        validate: {
+          required: false
+        },
+        type: 'resource'
+      }
+    ],
+    access: [],
+    submissionAccess: []
+  };
+  
+  template.resources.b = {
+    title: 'B',
+    type: 'resource',
+    name: 'b',
+    path: 'b',
+    components: [
+      {
+        isNew: false,
+        type: 'resource',
+        validate: {
+          required: false
+        },
+        persistent: true,
+        protected: false,
+        multiple: false,
+        searchFields: '',
+        selectFields: '',
+        template: '<span>{{ item.data }}</span>',
+        defaultValue: '',
+        resource: 'a',
+        placeholder: 'A',
+        key: 'a',
+        label: 'A',
+        tableView: true,
+        input: true
+      }
+    ],
+    access: [],
+    submissionAccess: []
+  };
+
   // Add some users.
   template.users = {
     // An owner of the project.

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@ var Q = require('q');
 var _ = require('lodash');
 var async = require('async');
 var assert = require('assert');
+var formioUtils = require('formio-utils');
 
 // Bootstrap the test environment.
 var ready = Q.defer();
@@ -57,7 +58,20 @@ describe('Bootstrap Test modules', function() {
     comparison = _.clone(template, true);
 
     var importer = require('../src/templates/import')(app.formio);
-    importer.template(template, done);
+    importer.template(template, function(err) {
+      if (err) {
+        return done(err);
+      }
+
+      var resourceA = template.resources.a;
+      var resourceB = template.resources.b;
+      var resourceComponentA = formioUtils.getComponent(resourceB.components, 'a');
+      var resourceComponentB = formioUtils.getComponent(resourceA.components, 'b');
+
+      assert.equal(resourceA._id, resourceComponentA.resource, 'Resource B\'s resource component for A should have the correct resource id');
+      assert.equal(resourceB._id, resourceComponentB.resource, 'Resource A\'s resource component for B should have the correct resource id');
+      done();
+    });
   });
 
   it('Should be able to export what was imported', function(done) {


### PR DESCRIPTION
Defer replacing resource component ids until all resources are created, so nested dependencies don't crash the import.