### PR TITLE
Bugfix/fa 713

### DIFF
--- a/src/util/delete.js
+++ b/src/util/delete.js
@@ -2,13 +2,6 @@
 
 var _ = require('lodash');
 var async = require('async');
-var debug = {
-  submission: require('debug')('formio:util:delete#submission'),
-  form: require('debug')('formio:util:delete#form'),
-  action: require('debug')('formio:util:delete#action'),
-  role: require('debug')('formio:util:delete#role'),
-  roleAccess: require('debug')('formio:util:delete#roleAccess')
-};
 
 /**
  *
@@ -22,18 +15,17 @@ module.exports = function(router) {
    * Flag a submission as deleted. If given a subId, one submission will be flagged; if given a formId, then all the
    * submissions for that formId will be flagged.
    *
-   * @param subId {string|ObjectId}
+   * @param {String|ObjectId} subId
    *   The submission id to flag as deleted.
-   * @param forms {array}
+   * @param {Array} forms
    *   A list of form ids to flag all submissions as deleted.
-   * @param next
+   * @param {Function} next
    *   The callback function to return the results.
-   *
-   * @returns {*}
    */
   var deleteSubmission = function(subId, forms, next) {
+    var _debug = require('debug')('formio:delete:submission');
     if (!subId && !forms) {
-      debug.submission('Skipping');
+      _debug('Skipping');
       return next();
     }
     // Convert the forms to an array if only one was provided.
@@ -41,74 +33,58 @@ module.exports = function(router) {
       forms = [forms];
     }
 
+    // Build the query, using either the subId or forms array.
+    var query = {deleted: {$eq: null}};
     if (subId) {
-      router.formio.resources.submission.model.findOne({_id: subId, deleted: {$eq: null}}, function(err, submission) {
-        if (err) {
-          debug.submission(err);
-          return next(err);
-        }
-        if (!submission) {
-          debug.submission('No submission found with subId: ' + subId);
-          return next();
-        }
-
-        submission.deleted = (new Date()).getTime();
-        submission.save(function(err, submission) {
-          if (err) {
-            debug.submission(err);
-            return next(err);
-          }
-
-          debug.submission(submission);
-          next(null, submission);
-        });
-      });
+      query._id = subId;
     }
     else {
-      router.formio.resources.submission.model.find({form: {$in: forms}, deleted: {$eq: null}})
-        .exec(function(err, submissions) {
+      query.form = {$in: forms};
+    }
+
+    _debug('Deleting ' + (subId ? 'single submission' : 'multiple submissions'));
+    _debug(query);
+    router.formio.resources.submission.model.find(query, function(err, submissions) {
+      if (err) {
+        _debug(err);
+        return next(err);
+      }
+      if (!submissions || submissions.length === 0) {
+        _debug('No submissions found.');
+        return next();
+      }
+
+      submissions.forEach(function(submission) {
+        submission.deleted = Date.now();
+        submission.save(function(err, submission) {
           if (err) {
-            debug.submission(err);
+            _debug(err);
             return next(err);
           }
-          if (!submissions || submissions.length === 0) {
-            debug.submission('No submissions found for the forms: ' + JSON.stringify(forms));
-            return next();
-          }
 
-          submissions.forEach(function(submission) {
-            submission.deleted = (new Date()).getTime();
-            submission.save(function(err, submission) {
-              if (err) {
-                debug.submission(err);
-                return next(err);
-              }
-
-              debug.submission(submission);
-            });
-          });
-
-          next();
+          _debug(submission);
         });
-    }
+      });
+
+      next();
+    });
   };
 
   /**
    * Flag an Action as deleted. If given a actionId, one action will be flagged; if given a formId, or array of formIds,
    * then all the Actions for that form, or forms, will be flagged.
    *
-   * @param actionId {string|ObjectId}
+   * @param {String|ObjectId} actionId
    *   The Action id to flag as deleted.
-   * @param forms {string|ObjectId|array}
+   * @param {String|ObjectId|Array} forms
    *   A list of form ids to flag all Actions as deleted.
-   * @param next
+   * @param {Function} next
    *   The callback function to return the results.
-   *
-   * @returns {*}
    */
   var deleteAction = function(actionId, forms, next) {
+    var _debug = require('debug')('formio:delete:action');
     if (!actionId && !forms) {
-      debug.action('Skipping');
+      _debug('Skipping');
       return next();
     }
     // Convert the forms to an array if only one was provided.
@@ -116,107 +92,92 @@ module.exports = function(router) {
       forms = [forms];
     }
 
-    debug.action('Deleting ' + (actionId ? 'single action' : 'multiple actions'));
+    var query = {deleted: {$eq: null}};
     if (actionId) {
-      router.formio.actions.model.findOne({_id: actionId, deleted: {$eq: null}}, function(err, action) {
-        if (err) {
-          debug.action(err);
-          return next(err);
-        }
-        if (!action) {
-          debug.action('No action found with _id: ' + actionId);
-          return next();
-        }
+      query._id = actionId;
+    }
+    else {
+      query.form = {$in: forms};
+    }
 
+
+    _debug('Deleting ' + (actionId ? 'single action' : 'multiple actions'));
+    _debug(query);
+    router.formio.actions.model.find(query, function(err, actions) {
+      if (err) {
+        _debug(err);
+        return next(err);
+      }
+      if (!actions || actions.length === 0) {
+        _debug('No actions found.');
+        return next();
+      }
+
+      actions.forEach(function(action) {
         action.settings = action.settings || {};
-        action.deleted = (new Date()).getTime();
+        action.deleted = Date.now();
         action.save(function(err, action) {
           if (err) {
-            debug.action(err);
+            _debug(err);
             return next(err);
           }
 
-          debug.action(action);
-          next();
+          _debug(action);
         });
       });
-    }
-    else {
-      router.formio.actions.model.find({form: {$in: forms}, deleted: {$eq: null}}, function(err, actions) {
-        if (err) {
-          debug.action(err);
-          return next(err);
-        }
-        if (!actions || actions.length === 0) {
-          debug.action('No action found with form _id\'s: ' + JSON.stringify(forms));
-          return next();
-        }
 
-        actions.forEach(function(action) {
-          action.settings = action.settings || {};
-          action.deleted = (new Date()).getTime();
-          action.save(function(err, action) {
-            if (err) {
-              debug.action(err);
-              return next(err);
-            }
-
-            debug.action(action);
-          });
-        });
-
-        // Continue once all the forms have been updated.
-        next();
-      });
-    }
+      // Continue once all the forms have been updated.
+      next();
+    });
   };
 
   /**
    * Flag a form as deleted. If given a formId, one form will be flagged;
    *
-   * @param formId {string|ObjectId}}
+   * @param {String|ObjectId} formId
    *   The form id to flag as deleted.
-   * @param next
+   * @param {Function} next
    *   The callback function to return the results.
-   *
-   * @returns {*}
    */
   var deleteForm = function(formId, next) {
+    var _debug = require('debug')('formio:delete:form');
     if (!formId) {
-      debug.form('Skipping');
+      _debug('Skipping');
       return next();
     }
 
-    router.formio.resources.form.model.findOne({_id: formId, deleted: {$eq: null}}, function(err, form) {
+    var query = {_id: formId, deleted: {$eq: null}};
+    _debug(query);
+    router.formio.resources.form.model.findOne(query, function(err, form) {
       if (err) {
-        debug.form(err);
+        _debug(err);
         return next(err);
       }
       if (!form) {
-        debug.form('No form found with the _id: ' + formId);
+        _debug('No form found with the _id: ' + formId);
         return next();
       }
 
-      form.deleted = (new Date()).getTime();
+      form.deleted = Date.now();
       form.save(function(err, form) {
         if (err) {
-          debug.form(err);
+          _debug(err);
           return next(err);
         }
 
         deleteAction(null, formId, function(err) {
           if (err) {
-            debug.form(err);
+            _debug(err);
             return next(err);
           }
 
           deleteSubmission(null, formId, function(err) {
             if (err) {
-              debug.form(err);
+              _debug(err);
               return next(err);
             }
 
-            debug.form(form);
+            _debug(form);
             next();
           });
         });
@@ -225,19 +186,25 @@ module.exports = function(router) {
   };
 
   /**
+   * Delete all known references to access for the given role.
    *
-   * @param roleId
-   * @param next
-   * @returns {*}
+   * @param {String|ObjectId} roleId
+   *   The roleId to delete access for.
+   * @param {Object} req
+   *   The express callback function.
+   * @param {Function} next
+   *   The callback function to return the results.
    */
   var deleteRoleAccess = function(roleId, req, next) {
+    var util = router.formio.util;
+    var _debug = require('debug')('formio:delete:roleaccess');
     if (!roleId) {
-      debug.roleAccess('Skipping');
+      _debug('Skipping');
       return next();
     }
 
     // Convert the roldId to a string for comparison.
-    roleId = roleId.toString();
+    roleId = util.idToString(roleId);
 
     // The access types to check.
     var accessType = ['access', 'submissionAccess'];
@@ -248,7 +215,7 @@ module.exports = function(router) {
     /**
      * Remove the roleId from the forms' access types.
      *
-     * @param cb {function}
+     * @param {Function} cb
      *   The callback function to invoke after the role has been removed.
      */
     var removeFromForm = function(cb) {
@@ -262,20 +229,21 @@ module.exports = function(router) {
       });
 
       var query = hook.alter('formQuery', {_id: {$in: formIds}, $or: or}, req);
+      _debug(query);
       router.formio.resources.form.model.find(query)
         .snapshot(true)
         .exec(function(err, forms) {
           if (err) {
-            debug.roleAccess(err);
+            _debug(err);
             return cb(err);
           }
           if (!forms || forms.length === 0) {
-            debug.roleAccess('No forms found with the query: ' + JSON.stringify(query));
+            _debug('No forms found with the query: ' + JSON.stringify(query));
             return cb();
           }
 
           // Iterate each form and remove the role.
-          debug.roleAccess('Found ' + forms.length + ' forms to modify.');
+          _debug('Found ' + forms.length + ' forms to modify.');
           async.eachSeries(forms, function(form, done) {
             // Iterate each access type to remove the role.
             accessType.forEach(function(access) {
@@ -284,9 +252,7 @@ module.exports = function(router) {
               // Iterate the roles for each permission type, and remove the given roleId.
               for (var b = 0; b < temp.length; b++) {
                 // Convert the ObjectIds to strings for comparison.
-                temp[b].roles = _.map((temp[b].roles || []), function(e) {
-                  return e.toString();
-                });
+                temp[b].roles = _.map((temp[b].roles || []), util.idToString);
 
                 // Remove the given roleId if it was defined in the access.
                 if (temp[b].roles.indexOf(roleId) !== -1) {
@@ -299,16 +265,16 @@ module.exports = function(router) {
 
             form.save(function(err, form) {
               if (err) {
-                debug.roleAccess(err);
+                _debug(err);
                 return done(err);
               }
 
-              debug.roleAccess(JSON.stringify(form));
+              _debug(JSON.stringify(form));
               done();
             });
           }, function(err) {
             if (err) {
-              debug.roleAccess(err);
+              _debug(err);
               return cb(err);
             }
 
@@ -320,29 +286,29 @@ module.exports = function(router) {
     /**
      * Remove the roleId from the submissions for the given formIds.
      *
-     * @param cb {function}
+     * @param {Function} cb
      *   The callback function to invoke after the roles have been removed.
      */
     var removeFromSubmissions = function(cb) {
+      var util = router.formio.util;
       // Find all submissions that contain the role in its roles.
       var query = {form: {$in: formIds}, deleted: {$eq: null}, roles: roleId};
+      _debug(query);
       router.formio.resources.submission.model.find(query)
         .snapshot(true)
         .exec(function(err, submissions) {
           if (err) {
-            debug.roleAccess(err);
+            _debug(err);
             return cb(err);
           }
           if (!submissions || submissions.length === 0) {
-            debug.roleAccess('No submissions found with given query: ' + JSON.stringify(query));
+            _debug('No submissions found with given query: ' + JSON.stringify(query));
             return cb();
           }
 
           // Iterate each submission to filter the roles.
           async.eachSeries(submissions, function(submission, done) {
-            var temp = _.map((submission.toObject().roles || []), function(e) {
-              return e.toString();
-            });
+            var temp = _.map((submission.toObject().roles || []), util.idToString);
 
             // Omit the given role from all submissions.
             if (temp.indexOf(roleId) !== -1) {
@@ -352,16 +318,16 @@ module.exports = function(router) {
             submission.set('roles', temp);
             submission.save(function(err, submission) {
               if (err) {
-                debug.roleAccess(err);
+                _debug(err);
                 return done(err);
               }
 
-              debug.roleAccess(submission);
+              _debug(submission);
               done();
             });
           }, function(err) {
             if (err) {
-              debug.roleAccess(err);
+              _debug(err);
               return cb(err);
             }
 
@@ -374,9 +340,11 @@ module.exports = function(router) {
       .snapshot(true)
       .exec(function(err, forms) {
         if (err) {
+          _debug(err);
           return next(err);
         }
         if (!forms) {
+          _debug('No forms given.');
           return next();
         }
 
@@ -384,14 +352,14 @@ module.exports = function(router) {
         formIds = _.map(forms, function(form) {
           return form.toObject()._id.toString();
         });
-        debug.roleAccess('Forms: ' + JSON.stringify(formIds));
+        _debug('Forms: ' + JSON.stringify(formIds));
 
         async.series([
           removeFromForm,
           removeFromSubmissions
         ], function(err) {
           if (err) {
-            debug.roleAccess(err);
+            _debug(err);
             return next(err);
           }
 
@@ -403,43 +371,47 @@ module.exports = function(router) {
   /**
    * Flag a Role as deleted. If given a roleId, one Role will be flagged;
    *
-   * @param roleId {string|ObjectId}
+   * @param {String|ObjectId} roleId
    *   The Role id to flag as deleted.
-   * @param next
+   * @param {Object} req
+   *   The express request object.
+   * @param {Function} next
    *   The callback function to return the results.
-   *
-   * @returns {*}
    */
   var deleteRole = function(roleId, req, next) {
+    var util = router.formio.util;
+    var _debug = require('debug')('formio:delete:role');
     if (!roleId) {
-      debug.role('Skipping');
+      _debug('Skipping');
       return next();
     }
 
-    router.formio.resources.role.model.findOne({_id: roleId, deleted: {$eq: null}}, function(err, role) {
+    var query = {_id: util.idToBson(roleId), deleted: {$eq: null}};
+    _debug(query);
+    router.formio.resources.role.model.findOne(query, function(err, role) {
       if (err) {
-        debug.role(err);
+        _debug(err);
         return next(err);
       }
       if (!role) {
-        debug.role('No role found with _id: ' + roleId);
+        _debug('No role found with _id: ' + roleId);
         return next();
       }
 
-      role.deleted = (new Date()).getTime();
+      role.deleted = Date.now();
       role.save(function(err, role) {
         if (err) {
-          debug.role(err);
+          _debug(err);
           return next(err);
         }
 
         deleteRoleAccess(roleId, req, function(err) {
           if (err) {
-            debug.role(err);
+            _debug(err);
             return next(err);
           }
 
-          debug.role(role);
+          _debug(role);
           next();
         });
       });

--- a/src/util/delete.js
+++ b/src/util/delete.js
@@ -56,6 +56,7 @@ module.exports = function(router) {
 
       submissions.forEach(function(submission) {
         submission.deleted = Date.now();
+        submission.markModified('deleted');
         submission.save(function(err, submission) {
           if (err) {
             _debug(err);
@@ -116,6 +117,7 @@ module.exports = function(router) {
       actions.forEach(function(action) {
         action.settings = action.settings || {};
         action.deleted = Date.now();
+        action.markModified('deleted');
         action.save(function(err, action) {
           if (err) {
             _debug(err);
@@ -159,6 +161,7 @@ module.exports = function(router) {
       }
 
       form.deleted = Date.now();
+      form.markModified('deleted');
       form.save(function(err, form) {
         if (err) {
           _debug(err);
@@ -399,6 +402,7 @@ module.exports = function(router) {
       }
 
       role.deleted = Date.now();
+      role.markModified('deleted');
       role.save(function(err, role) {
         if (err) {
           _debug(err);


### PR DESCRIPTION
Refactoring delete utilities. Changing debug namespace from `formio:util:delete#*` to `formio:delete:*`.

Adding forced `document.markModified('deleted')`
Changing timestamps to use `Date.now()` rather than `(new Date()).getTime()`
