### PR TITLE
Fix not equal conditional actions

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -196,7 +196,7 @@ module.exports = function(router) {
             if (
               action.condition &&
               action.condition.field &&
-              (action.condition.eq === 'equals') &&
+              (action.condition.eq === 'equals') ===
               (req.body.data[action.condition.field] !== action.condition.value)
             ) {
               execute = false;

--- a/test/actions.js
+++ b/test/actions.js
@@ -2188,6 +2188,96 @@ module.exports = function(app, template, hook) {
             done();
           });
       });
+
+      it('Executes a does not equal action when not equal', function(done) {
+        var owner = (app.hasProjects || docker) ? template.formio.owner : template.users.admin;
+        helper = new Helper(owner);
+        helper
+          .project()
+          .resource([
+            {
+              type: 'email',
+              persistent: true,
+              unique: false,
+              protected: false,
+              defaultValue: '',
+              suffix: '',
+              prefix: '',
+              placeholder: 'Enter your email address',
+              key: 'email',
+              label: 'Email',
+              inputType: 'email',
+              tableView: true,
+              input: true
+            },
+            {
+              type: 'selectboxes',
+              label: 'Roles',
+              key: 'roles',
+              input: true,
+              values: [
+                {
+                  label: 'Administrator',
+                  value: 'administrator'
+                },
+                {
+                  label: 'Authenticated',
+                  value: 'authenticated'
+                }
+              ]
+            }
+          ])
+          .action({
+            title: 'Role Assignment',
+            name: 'role',
+            priority: 1,
+            handler: ['after'],
+            method: ['create'],
+            condition: {
+              field: 'email',
+              equal: 'notEqual',
+              value: 'none@example.com'
+            },
+            settings: {
+              association: 'new',
+              type: 'add',
+              role: 'authenticated'
+            }
+          })
+          .submission({
+            email: 'test@example.com',
+            roles: ['test']
+          })
+          .execute(function(err) {
+            if (err) {
+              return done(err);
+            }
+
+            var submission = helper.getLastSubmission();
+            assert(submission.roles.indexOf(helper.template.roles.administrator._id) === -1);
+            assert(submission.roles.indexOf(helper.template.roles.authenticated._id) !== -1);
+            done();
+          });
+      });
+
+      it('Does not execute a does not equal action when equal', function(done) {
+        var owner = (app.hasProjects || docker) ? template.formio.owner : template.users.admin;
+        helper.submission({
+            email: 'none@example.com',
+            roles: ['test']
+          })
+          .execute(function(err) {
+            if (err) {
+              return done(err);
+            }
+
+            var submission = helper.getLastSubmission();
+            assert(submission.roles.indexOf(helper.template.roles.administrator._id) === -1);
+            assert(submission.roles.indexOf(helper.template.roles.authenticated._id) === -1);
+            done();
+          });
+      });
+
     });
   });
 };


### PR DESCRIPTION
The Does Not Equal setting on conditional actions was broken in commit d357f7a where an === was changed to &&. This fixes it and creates tests.