### PR TITLE
Coerse null signatures into empty strings to keep bad errors from being thrown.

### DIFF
--- a/src/actions/fields/signature.js
+++ b/src/actions/fields/signature.js
@@ -4,6 +4,18 @@ var _ = require('lodash');
 
 module.exports = function(formio) {
   return {
+    beforePost: function(component, path, validation, req, res, next) {
+      if (!req.body.data) {
+        return next();
+      }
+      var value = _.get(req.body, 'data.' + path);
+
+      // Coerse the value into an empty string.
+      if (!value && value !== '') {
+        _.set(req.body, 'data.' + path, '');
+      }
+      return next();
+    },
     beforePut: function(component, path, validation, req, res, next) {
       if (!req.body.data) {
         return next();
@@ -12,6 +24,13 @@ module.exports = function(formio) {
       // Ensure that signatures are not ever wiped out with a PUT request
       // of data that came from the index request (where the signature is not populated).
       var value = _.get(req.body, 'data.' + path);
+
+      // Coerse the value into an empty string.
+      if (!value && (value !== '')) {
+        value = '';
+        _.set(req.body, 'data.' + path, '');
+      }
+
       if (
         (typeof value !== 'string') ||
         ((value !== '') && (value.substr(0, 5) !== 'data:'))

--- a/test/submission.js
+++ b/test/submission.js
@@ -42,10 +42,42 @@ module.exports = function(app, template, hook) {
               return done(err);
             }
 
-            var submission = helper.getLastSubmission();
-            assert.deepEqual(test.submission, submission.data);
+            signatureSubmission1 = helper.getLastSubmission();
+            assert.deepEqual(test.submission, signatureSubmission1.data);
             done();
           });
+      });
+
+      var signatureSubmission1 = null;
+      it('Saves submission with a null signature.', function(done) {
+        var test = _.cloneDeep(require('./forms/singlecomponents2.js'));
+        test.submission.signature2 = null;
+        helper
+          .form('test', test.components)
+          .submission(test.submission)
+          .execute(function(err) {
+            if (err) {
+              return done(err);
+            }
+
+            signatureSubmission1 = helper.getLastSubmission();
+            // Should coerse the value to an empty string.
+            test.submission.signature2 = "";
+            assert.deepEqual(test.submission, signatureSubmission1.data);
+            done();
+          });
+      });
+
+      it('Updates the submission with a null signature', function(done) {
+        var test = _.cloneDeep(require('./forms/singlecomponents2.js'));
+        var updateSub = _.cloneDeep(signatureSubmission1);
+        updateSub.data.signature2 = null;
+        helper.updateSubmission(updateSub, function(err, updated) {
+          // Should coerse the value to an empty string.
+          test.submission.signature2 = "";
+          assert.deepEqual(test.submission, updated.data);
+          done();
+        });
       });
 
       var signatureSubmission = null;
@@ -145,9 +177,9 @@ module.exports = function(app, template, hook) {
             var submission = helper.getLastSubmission();
             assert.equal(submission.name, 'ValidationError');
             assert.equal(submission.details.length, 1);
-            assert.equal(submission.details[0].message, '"signature2" is required');
+            assert.equal(submission.details[0].message, '"signature2" is not allowed to be empty');
             assert.equal(submission.details[0].path, 'signature2');
-            assert.equal(submission.details[0].type, 'any.required');
+            assert.equal(submission.details[0].type, 'any.empty');
             done();
           });
       });


### PR DESCRIPTION
…ng thrown.