### PR TITLE
Pass dummy router from install to import

### DIFF
--- a/install.js
+++ b/install.js
@@ -333,7 +333,7 @@ module.exports = function(formio, items, done) {
 
       // Get the form.io service.
       util.log('Importing template...'.green);
-      var importer = require('./src/templates/import')(formio);
+      var importer = require('./src/templates/import')({formio: formio});
       importer.template(template, function(err, template) {
         if (err) {
           return done(err);


### PR DESCRIPTION
New ./src/templates/import.js is expecting a router with a formio
Old install.js is just passing a formio
Pass something that looks like a router with a formio from install to import

