### PR TITLE
Fix 'Unknown resource' error on PUT of form which has multiple save a…

### DIFF
--- a/src/actions/SaveSubmission.js
+++ b/src/actions/SaveSubmission.js
@@ -174,6 +174,7 @@ module.exports = function(router) {
         req.body.externalIds = req.body.externalIds || [];
         req.body.externalIds.push({
           type: 'resource',
+          resource: this.settings.resource,
           id: res.resource.item._id.toString()
         });
       }
@@ -232,7 +233,7 @@ module.exports = function(router) {
           }
 
           // Find the external submission.
-          var external = _.find(currentSubmission.externalIds, {type: 'resource'});
+          var external = _.find(currentSubmission.externalIds, {type: 'resource', resource: this.settings.resource});
           if (!external) {
             return then();
           }

--- a/src/models/Submission.js
+++ b/src/models/Submission.js
@@ -5,6 +5,7 @@ var mongoose = require('mongoose');
 // Defines what each external ID should be.
 var ExternalIdSchema = mongoose.Schema({
   type: String,
+  resource: String,
   id: String
 });
 


### PR DESCRIPTION
Create a form which contains two save actions to two different resource types (besides the form itself) and another save action to the form itself.
Initial POST will work.
Subsequent PUT will fail with 'Unknown resource' because members of submission's externalIds array are undifferentiated with regard to resource or action.
Proposed fix adds resource type ids to externalIds members.
Would expect there to still be a problem if a form contained two save actions to the same resource type.
Would try storing action name or id instead but both actions have name of 'save' at that point and I don't see their ids.