### PR TITLE
Validate email on first installation

### DIFF
--- a/install.js
+++ b/install.js
@@ -400,6 +400,8 @@ module.exports = function(formio, items, done) {
         {
           name: 'email',
           description: 'Enter your email address for the root account.',
+          pattern: /^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/,
+          message: 'Must be a valid email',
           required: true
         },
         {


### PR DESCRIPTION
fixed #365 

Email validation for username based on w3c input type email regex (https://www.w3.org/TR/2012/WD-html-markup-20120320/input.email.html)