### PR TITLE
Force node check version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "license": "SEE LICENSE IN LICENSE.txt",
   "main": "index.js",
   "scripts": {
-    "test": "env TEST_SUITE=1 mocha test/test.js -b -t 60000",
-    "start": "node main.js",
-    "lint": "eslint ."
+    "test": "npm run version && env TEST_SUITE=1 mocha test/test.js -b -t 60000",
+    "start": "npm run version && node main.js",
+    "lint": "eslint .",
+    "version": "check-node-version --node '>=6.0.0'"
   },
   "author": "support@form.io",
   "engines": {
@@ -21,6 +22,7 @@
     "async": "^1.5.2",
     "bcrypt": "^0.8.7",
     "body-parser": "^1.17.1",
+    "check-node-version": "^2.1.0",
     "clone": "^1.0.2",
     "colors": "^1.1.2",
     "config": "^1.24.0",


### PR DESCRIPTION
In package.json there is:
```
"engines": {
    "node": ">=6.0.0"
  },
```
But npm didnt force the node version, is just declarative.
So I added check-node-version to force it to use node >= 6.0.0