### PR TITLE
Pass components with action condition textarea for ACE editor autocomplete

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -424,7 +424,7 @@ module.exports = function(router) {
                         type: 'textarea',
                         input: true,
                         key: 'custom',
-                        components: form.components,
+                        editorComponents: form.components,
                         placeholder: customPlaceHolder
                       }
                     ]

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -424,6 +424,7 @@ module.exports = function(router) {
                         type: 'textarea',
                         input: true,
                         key: 'custom',
+                        components: form.components,
                         placeholder: customPlaceHolder
                       }
                     ]


### PR DESCRIPTION
Use ACE editor anywhere user can edit JavaScript.
To enable app just needs to include script tags for ACE build (see related pull request in formio-app-formio).
If app doesn't include ACE build then fall back on textarea for editing.
Autocomplete includes API names of form's components (press Ctrl + Space).
See related pull requests in ngFormio, ngFormBuilder, and formio-app-formio.