### PR TITLE
Set child form parent

### DIFF
--- a/src/actions/fields/form.js
+++ b/src/actions/fields/form.js
@@ -1,0 +1,56 @@
+'use strict';
+
+var _ = require('lodash');
+
+module.exports = function(formio) {
+  // Set parent submission id in externalIds of child form component's submission
+  var setChildFormParenthood = function(component, path, validation, req, res, next) {
+    if (res.resource && res.resource.item && res.resource.item.data) {
+      // Get child form component's value
+      let compValue = _.get(res.resource.item.data, path);
+
+      // Fetch the child form's submission
+      if (compValue && compValue._id) {
+        formio.resources.submission.model.findOne(
+          {_id: compValue._id, deleted: {$eq: null}}
+        ).exec(function(err, submission) {
+          if (err) {
+            return formio.util.log(err);
+          }
+
+          // Update the submission's externalIds.
+          var found = false;
+          submission.externalIds = submission.externalIds || [];
+          _.each(submission.externalIds, function(externalId) {
+            if (externalId.type === 'parent') {
+              found = true;
+            }
+          });
+          if (!found) {
+            submission.externalIds.push({
+              type: 'parent',
+              id: res.resource.item._id
+            });
+            submission.save(function(err, submission) {
+              if (err) {
+                return formio.util.log(err);
+              }
+            });
+          }
+        });
+      }
+    }
+
+    return next();
+  };
+
+  return {
+    afterPost: function(component, path, validation, req, res, next) {
+      return setChildFormParenthood(component, path, validation, req, res, next);
+    },
+
+    afterPut:  function(component, path, validation, req, res, next) {
+      return setChildFormParenthood(component, path, validation, req, res, next);
+    }
+  };
+};

--- a/src/actions/fields/index.js
+++ b/src/actions/fields/index.js
@@ -4,6 +4,7 @@ module.exports = function(router) {
   return {
     signature: require('./signature')(router.formio),
     password: require('./password')(router.formio),
+    form: require('./form')(router.formio),
     email: require('./email')(router.formio)
   };
 };

--- a/src/middleware/submissionHandler.js
+++ b/src/middleware/submissionHandler.js
@@ -383,56 +383,6 @@ module.exports = function(router, resourceName, resourceId) {
       done();
     };
 
-    /**
-     * Set parenthood of child forms if not already done
-     *
-     * @param req
-     * @param res
-     * @param done
-     */
-    var setChildFormParenthood = function(req, res, done) {
-      if (req.method !== 'POST' && req.method !== 'PUT') {
-        return done();
-      }
-
-      _.each(req.flattenedComponents, function(component, key) {
-        if (component.type === 'form') {
-          var data = req.submission.data[key];
-
-          if (data) {
-            router.formio.resources.submission.model.findOne(
-              {_id: data._id, deleted: {$eq: null}}
-            ).exec(function(err, submission) {
-              if (err) {
-                return router.formio.util.log(err);
-              }
-
-              // Update the submission's externalIds.
-              var found = false;
-              submission.externalIds = submission.externalIds || [];
-              _.each(submission.externalIds, function(externalId) {
-                if (externalId.type === 'parent') {
-                  found = true;
-                }
-              });
-              if (!found) {
-                submission.externalIds.push({
-                  type: 'parent',
-                  id: res.resource.item._id
-                });
-                submission.save(function(err, submission) {
-                  if (err) {
-                    return router.formio.util.log(err);
-                  }
-                });
-              }
-            });
-          }
-        }
-      });
-      done();
-    };
-
     // Add before handlers.
     var before = 'before' + method.method;
     handlers[before] = function(req, res, next) {
@@ -455,7 +405,6 @@ module.exports = function(router, resourceName, resourceId) {
       async.series([
         async.apply(executeActions('after'), req, res),
         async.apply(executeFieldHandlers, true, req, res),
-        async.apply(setChildFormParenthood, req, res),
         async.apply(ensureResponse, req, res)
       ], next);
     };

--- a/src/middleware/submissionHandler.js
+++ b/src/middleware/submissionHandler.js
@@ -239,7 +239,7 @@ module.exports = function(router, resourceName, resourceId) {
         req.skipResource = true;
 
         // Only allow the data to go through.
-        var properties = hook.alter('submissionParams', ['data', 'owner', 'access', 'metadata', 'deleted']);
+        var properties = hook.alter('submissionParams', ['data', 'owner', 'access']);
         req.body = _.pick(req.body, properties);
 
         // Ensure there is always data provided on POST.


### PR DESCRIPTION
In multi-form workflows it can be useful to be able to navigate from a child form component's submission to the parent's submission.
Set an externalId of type _parent_ in the children back up to the parent.