### PR TITLE
Return SQL Server query results from get action

### DIFF
--- a/src/actions/SQLAction.js
+++ b/src/actions/SQLAction.js
@@ -244,7 +244,7 @@ module.exports = function(router) {
               if ((method === 'post') && !err) {
                 postExecute.call(this, result[0]);
               }
-              if ((method === 'get' ) && !err) {
+              if ((method === 'get' ) && !err && res && res.resource && res.resource.item) {
                 res.resource.item.metadata = res.resource.item.metadata || {};
                 res.resource.item.metadata[this.title] = result.toTable();
               }


### PR DESCRIPTION
My form has a SQL Query action titled 'SQL Select'.
It runs the query _select name, age from flintstones where id = '{{ data.id }}'_ on Microsoft SQL Server.
The action executes After Read.
Would like to be able to access the query results in Calculated Value scripts of Name and Age components.

Code change returns results of SQL Server get query in submission's metadata.
So Calculated Value scripts can access query results with code like _value = submission.metadata['SQL Select'].rows[0][0];_
