### PR TITLE
Translate action dropdown items

### DIFF
--- a/src/actions/EmailAction.js
+++ b/src/actions/EmailAction.js
@@ -53,7 +53,7 @@ module.exports = function(router) {
           label: 'Transport',
           key: 'transport',
           placeholder: 'Select the email transport.',
-          template: '<span>{{ item.title }}</span>',
+          template: '<span>{{ item.title | formioTranslate }}</span>',
           defaultValue: 'default',
           dataSrc: 'json',
           data: {

--- a/src/actions/LoginAction.js
+++ b/src/actions/LoginAction.js
@@ -56,7 +56,7 @@ module.exports = function(router) {
         dataSrc: 'url',
         data: {url: basePath + '?type=resource'},
         valueProperty: '_id',
-        template: '<span>{{ item.title }}</span>',
+        template: '<span>{{ item.title | formioTranslate }}</span>',
         multiple: true,
         validate: {
           required: true
@@ -68,7 +68,7 @@ module.exports = function(router) {
         label: 'Username Field',
         key: 'username',
         placeholder: 'Select the username field',
-        template: '<span>{{ item.label || item.key }}</span>',
+        template: '<span>{{ (item.label || item.key) | formioTranslate }}</span>',
         dataSrc: 'url',
         data: {url: dataSrc},
         valueProperty: 'key',
@@ -83,7 +83,7 @@ module.exports = function(router) {
         label: 'Password Field',
         key: 'password',
         placeholder: 'Select the password field',
-        template: '<span>{{ item.label || item.key }}</span>',
+        template: '<span>{{ (item.label || item.key) | formioTranslate }}</span>',
         dataSrc: 'url',
         data: {url: dataSrc},
         valueProperty: 'key',

--- a/src/actions/ResetPassword.js
+++ b/src/actions/ResetPassword.js
@@ -64,7 +64,7 @@ module.exports = function(router) {
           dataSrc: 'url',
           data: {url: basePath + '?type=resource'},
           valueProperty: '_id',
-          template: '<span>{{ item.title }}</span>',
+          template: '<span>{{ item.title | formioTranslate }}</span>',
           multiple: true,
           validate: {
             required: true
@@ -76,7 +76,7 @@ module.exports = function(router) {
           label: 'Username Field',
           key: 'username',
           placeholder: 'Select the username field',
-          template: '<span>{{ item.label || item.key }}</span>',
+          template: '<span>{{ (item.label || item.key) | formioTranslate }}</span>',
           dataSrc: 'url',
           data: {url: dataSrc},
           valueProperty: 'key',
@@ -91,7 +91,7 @@ module.exports = function(router) {
           label: 'Password Field',
           key: 'password',
           placeholder: 'Select the password field',
-          template: '<span>{{ item.label || item.key }}</span>',
+          template: '<span>{{ (item.label || item.key) | formioTranslate }}</span>',
           dataSrc: 'url',
           data: {url: dataSrc},
           valueProperty: 'key',

--- a/src/actions/ResetPassword.js
+++ b/src/actions/ResetPassword.js
@@ -129,7 +129,7 @@ module.exports = function(router) {
           label: 'Transport',
           key: 'transport',
           placeholder: 'Select the email transport.',
-          template: '<span>{{ item.title }}</span>',
+          template: '<span>{{ item.title | formioTranslate }}</span>',
           defaultValue: 'default',
           dataSrc: 'json',
           data: {

--- a/src/actions/RoleAction.js
+++ b/src/actions/RoleAction.js
@@ -58,7 +58,7 @@ module.exports = function(router) {
             label: 'Resource Association',
             key: 'association',
             placeholder: 'Select the type of resource to perform role manipulation.',
-            template: '<span>{{ item.title }}</span>',
+            template: '<span>{{ item.title | formioTranslate }}</span>',
             dataSrc: 'json',
             data: {
               json: JSON.stringify([
@@ -84,7 +84,7 @@ module.exports = function(router) {
             label: 'Action Type',
             key: 'type',
             placeholder: 'Select whether this Action will Add or Remove the contained Role.',
-            template: '<span>{{ item.title }}</span>',
+            template: '<span>{{ item.title | formioTranslate }}</span>',
             dataSrc: 'json',
             data: {
               json: JSON.stringify([
@@ -110,7 +110,7 @@ module.exports = function(router) {
             label: 'Role',
             key: 'role',
             placeholder: 'Select the Role that this action will Add or Remove.',
-            template: '<span>{{ item.title }}</span>',
+            template: '<span>{{ item.title | formioTranslate }}</span>',
             dataSrc: 'json',
             data: {json: roles},
             valueProperty: '_id',

--- a/src/actions/SQLAction.js
+++ b/src/actions/SQLAction.js
@@ -74,7 +74,7 @@ module.exports = function(router) {
           label: 'SQL ServerType',
           key: 'type',
           placeholder: 'Select the SQL Server Type',
-          template: '<span>{{ item.title }}</span>',
+          template: '<span>{{ item.title | formioTranslate }}</span>',
           dataSrc: 'json',
           data: {
             json: JSON.stringify(serverTypes)

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -276,7 +276,7 @@ module.exports = function(router) {
             title: 'After'
           }
         ])},
-        template: '<span>{{ item.title }}</span>',
+        template: '<span>{{ item.title | formioTranslate }}</span>',
         valueProperty: 'name',
         multiple: true
       });
@@ -319,7 +319,7 @@ module.exports = function(router) {
             title: 'Index'
           }
         ])},
-        template: '<span>{{ item.title }}</span>',
+        template: '<span>{{ item.title | formioTranslate }}</span>',
         valueProperty: 'name',
         multiple: true
       });
@@ -370,7 +370,7 @@ module.exports = function(router) {
                     label : '',
                     key : 'eq',
                     placeholder : 'Select comparison',
-                    template : '<span>{{ item.label }}</span>',
+                    template : '<span>{{ item.label | formioTranslate }}</span>',
                     dataSrc : 'values',
                     data : {
                       values : [


### PR DESCRIPTION
In templates for select components.
Many of these items will come from the names of resources or fields created by the users in their own languages and not really need translation.
Others like the User and Admin resources and their fields are created by install and could stand to be translated. 
