### PR TITLE
Allow patch version differences in db schema.

### DIFF
--- a/src/db/index.js
+++ b/src/db/index.js
@@ -438,7 +438,7 @@ module.exports = function(formio) {
       debug.db('Current database (' + database + ') and Pending code sversions (' + code + ') are the same.');
       return false;
     }
-    else if (semver.gt(database, code)) {
+    else if (semver.major(database) !== semver.major(code) || semver.minor(database) !== semver.minor(code)) {
       unlock(function() {
         throw new Error(
           'The provided codebase version is more recent than the database schema version. Update the codebase and ' +

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -438,7 +438,7 @@ module.exports = function(formio) {
       debug.db('Current database (' + database + ') and Pending code sversions (' + code + ') are the same.');
       return false;
     }
-    else if (semver.major(database) !== semver.major(code) || semver.minor(database) !== semver.minor(code)) {
+    else if (['patch', 'prepatch', 'prelease'].indexOf(semver.diff(database, code)) === -1) {
       unlock(function() {
         throw new Error(
           'The provided codebase version is more recent than the database schema version. Update the codebase and ' +


### PR DESCRIPTION
I think the original intent of the db updates was to allow patch differences between the codebase. Apparently we never implemented allowing patch differences.