### PR TITLE
Adjust SQL action for breaking changes in mssql 4.1.0

### DIFF
--- a/src/actions/SQLAction.js
+++ b/src/actions/SQLAction.js
@@ -63,17 +63,17 @@ module.exports = function(router) {
           }
         }
 
-        next(null, [
-          {
-            type: 'select',
-            input: true,
-            label: 'SQL ServerType',
-            key: 'type',
-            placeholder: 'Select the SQL Server Type',
-            template: '<span>{{ item.title }}</span>',
-            dataSrc: 'json',
-            data: {
-              json: JSON.stringify(serverTypes)
+      next(null, [
+        {
+          type: 'select',
+          input: true,
+          label: 'SQL ServerType',
+          key: 'type',
+          placeholder: 'Select the SQL Server Type',
+          template: '<span>{{ item.title | formioTranslate }}</span>',
+          dataSrc: 'json',
+          data: {
+            json: JSON.stringify(serverTypes)
             },
             valueProperty: 'type',
             multiple: false
@@ -230,7 +230,8 @@ module.exports = function(router) {
               options: {encrypt: settings.azure ? true : false}
             };
 
-            mssql.connect(config, function(err) {
+            const pool = new mssql.ConnectionPool(config);
+            pool.connect(function(err) {
               if (err) {
                 if (wait) {
                   return next();
@@ -238,16 +239,16 @@ module.exports = function(router) {
                 return;
               }
 
-              const request = new mssql.Request();
+              const request = new mssql.Request(pool);
               request.query(`${query}; SELECT SCOPE_IDENTITY() as id;`, function(err, result) {
                 if ((method === 'post') && !err) {
-                  postExecute.call(this, result[0]);
+                  postExecute.call(this, result.recordset[0]);
                 }
                 if ((method === 'get' ) && !err && res && res.resource && res.resource.item) {
                   res.resource.item.metadata = res.resource.item.metadata || {};
-                  res.resource.item.metadata[this.title] = result.toTable();
+                  res.resource.item.metadata[this.title] = result.recordset.toTable();
                 }
-                mssql.close();
+                pool.close();
                 if (wait) {
                   return next();
                 }

--- a/src/actions/SQLAction.js
+++ b/src/actions/SQLAction.js
@@ -63,17 +63,17 @@ module.exports = function(router) {
           }
         }
 
-      next(null, [
-        {
-          type: 'select',
-          input: true,
-          label: 'SQL ServerType',
-          key: 'type',
-          placeholder: 'Select the SQL Server Type',
-          template: '<span>{{ item.title | formioTranslate }}</span>',
-          dataSrc: 'json',
-          data: {
-            json: JSON.stringify(serverTypes)
+        next(null, [
+          {
+            type: 'select',
+            input: true,
+            label: 'SQL ServerType',
+            key: 'type',
+            placeholder: 'Select the SQL Server Type',
+            template: '<span>{{ item.title }}</span>',
+            dataSrc: 'json',
+            data: {
+              json: JSON.stringify(serverTypes)
             },
             valueProperty: 'type',
             multiple: false


### PR DESCRIPTION
`mssql.connect` call is crashing server with error `Error: Global connection already exists. Call sql.close() first.`
Changed to use connection pool to connect.
Format of result object has changed in mssql 4.1.0.
Changed to use result object's recordset.
