### PR TITLE
Make schema model a first class model.

### DIFF
--- a/src/models/Schema.js
+++ b/src/models/Schema.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = function(formio) {
+  /**
+   * The Schema for Schema.
+   *
+   * @type {exports.Schema}
+   */
+  const SchemaSchema = new formio.mongoose.Schema({
+    key: {
+      type: String,
+      required: true
+    },
+    isLocked: {
+      type: Boolean,
+      default: false
+    },
+    version: {
+      type: String,
+      default: null
+    },
+    value: {
+      type: String,
+      default: null
+    },
+  }, {collection: 'schema'});
+
+  return {schema: SchemaSchema};
+};

--- a/src/models/models.js
+++ b/src/models/models.js
@@ -10,6 +10,7 @@ module.exports = function(router) {
   const models = hook.alter('models', {
     action: require('./Action')(router.formio),
     form: require('./Form')(router.formio),
+    schema: require('./Schema')(router.formio),
     submission: require('./Submission')(router.formio),
     role: require('./Role')(router.formio)
   });


### PR DESCRIPTION
By making "schema" a first class model we will be able to use the built in tools to read and write other values to the schema collection.