### PR TITLE
Enable unattended install driven by environment variables.

### DIFF
--- a/install.js
+++ b/install.js
@@ -160,6 +160,9 @@ module.exports = function(formio, items, done) {
      * @param done
      */
     areYouSure: function(done) {
+      if (process.env.UNATTENDED_INSTALL) {
+        done();
+      }
       prompt.get([
         {
           name: 'install',
@@ -180,6 +183,9 @@ module.exports = function(formio, items, done) {
 
     // Allow them to select the application.
     whatApp: function(done) {
+      if (process.env.UNATTENDED_INSTALL) {
+        done();
+      }
       const repos = [
         'None',
         'https://github.com/formio/formio-app-humanresources',
@@ -305,6 +311,10 @@ module.exports = function(formio, items, done) {
         templateFile = 'app';
         return done();
       }
+      if (process.env.UNATTENDED_INSTALL) {
+        templateFile = 'client';
+        done();
+      }
 
       let message = '\nWhich project template would you like to install?\n'.green;
       message += '\n   Please provide the local file path of the project.json file.'.yellow;
@@ -392,6 +402,12 @@ module.exports = function(formio, items, done) {
      * @param done
      */
     createRootUser: function(done) {
+      if (process.env.UNATTENDED_INSTALL) {
+        prompt.override = {
+          email: process.env.ROOT_EMAIL,
+          password: process.env.ROOT_PASSWORD
+        }
+      }
       if (!items.user) {
         return done();
       }

--- a/install.js
+++ b/install.js
@@ -160,7 +160,7 @@ module.exports = function(formio, items, done) {
      * @param done
      */
     areYouSure: function(done) {
-      if (process.env.UNATTENDED_INSTALL) {
+      if (process.env.ROOT_USER) {
         done();
       }
       prompt.get([
@@ -183,7 +183,7 @@ module.exports = function(formio, items, done) {
 
     // Allow them to select the application.
     whatApp: function(done) {
-      if (process.env.UNATTENDED_INSTALL) {
+      if (process.env.ROOT_USER) {
         done();
       }
       const repos = [
@@ -311,7 +311,7 @@ module.exports = function(formio, items, done) {
         templateFile = 'app';
         return done();
       }
-      if (process.env.UNATTENDED_INSTALL) {
+      if (process.env.ROOT_USER) {
         templateFile = 'client';
         done();
       }
@@ -402,7 +402,7 @@ module.exports = function(formio, items, done) {
      * @param done
      */
     createRootUser: function(done) {
-      if (process.env.UNATTENDED_INSTALL) {
+      if (process.env.ROOT_USER) {
         prompt.override = {
           email: process.env.ROOT_EMAIL,
           password: process.env.ROOT_PASSWORD


### PR DESCRIPTION
It would be helpful to be able to automate the install of form.io - this is a first pass at doing that (doesn't have docs, tests etc).

To use this first `export UNATTENDED_INSTALL=1` to skip the interactive prompts. Then you will want to create a config/custom-environment-variables.json file that specifies mapping of environment variables to config overrides - e.g.:

```
{
  "domain": "DOMAIN",
  "basePath": "",
  "mongo": "MONGO",
  "mongoSecret": "MONGOSECRET",
  "jwt": {
    "secret": "JWTSECRET"
  }
}
```

Then, export values for each of those variables and start the install.