### PR TITLE
Add npm install step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The fastest way to run this library locally is to use [Docker](https://docker.co
  - Open up your terminal and navigate to the unzipped folder of this library.
  - Type the following in your terminal
     ```
+    npm install
     docker-compose up
     ```
  - Go to the following URL in your browser.


### PR DESCRIPTION
Since `docker-compose.yml` mounts the local directory as a volume for the `formio` container, and the `Dockerfile` does not execute `npm install` when building the image, it is necessary to run `npm install` to make the required node modules available before attempting to start the containers.

Fixes https://github.com/formio/formio/issues/772.