### PR TITLE
Use python version 2.7.16-r1 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 # (note: using pinned versions to ensure immutable build environment)
 RUN apk update && \
     apk upgrade && \
-    apk add python=2.7.15-r3 && \
+    apk add python=2.7.16-r1 && \
     apk add make=4.2.1-r2 && \
     apk add g++=8.3.0-r0
 


### PR DESCRIPTION
2.7.15-r3 is no longer available, so building an image from this Dockerfile fails when trying to add it.

Fixes #783 