### PR TITLE
CORS: access control allow origin header added

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -3,6 +3,7 @@
   "appPort": 8080,
   "host": "localhost:3001",
   "protocol": "http",
+  "allowedOrigins": ["http://localhost:3000"],
   "domain": "http://localhost:3001",
   "basePath": "",
   "mongo": "mongodb://localhost:27017/formioapp",

--- a/config/default.json
+++ b/config/default.json
@@ -3,7 +3,7 @@
   "appPort": 8080,
   "host": "localhost:3001",
   "protocol": "http",
-  "allowedOrigins": ["http://localhost:3000"],
+  "allowedOrigins": ["*"],
   "domain": "http://localhost:3001",
   "basePath": "",
   "mongo": "mongodb://localhost:27017/formioapp",

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const path = require('path');
 const util = require('./src/util/util');
 require('colors');
 const Q = require('q');
+const cors = require('cors');
 const test = process.env.TEST_SUITE;
 const noInstall = process.env.NO_INSTALL;
 
@@ -52,17 +53,20 @@ module.exports = function(options) {
 
 
   //cors configuration
-  app.use(cors({
-    origin: function(origin, callback){
-      if(!origin) return callback(null, true);
-      if(config.allowedOrigins.indexOf(origin) === -1){
-        var msg = 'The CORS policy for this site does not ' +
-                  'allow access from the specified Origin.';
-        return callback(new Error(msg), false);
+  if(config.allowedOrigins) {
+    app.use(cors({
+      origin: function(origin, callback){
+        if(!origin) return callback(null, true);
+        if(config.allowedOrigins.indexOf(origin) === -1 && config.allowedOrigins.indexOf("*") === -1){
+          var msg = 'The CORS policy for this site does not ' +
+                    'allow access from the specified Origin.';
+                    console.log(config.allowedOrigins.indexOf("*"))
+          return callback(new Error(msg), false);
+        }
+        return callback(null, true);
       }
-      return callback(null, true);
-    }
-  }));
+    }));
+  }
   // Mount the client application.
   app.use('/', express.static(path.join(__dirname, '/client/dist')));
 

--- a/server.js
+++ b/server.js
@@ -50,6 +50,19 @@ module.exports = function(options) {
     express: app
   });
 
+
+  //cors configuration
+  app.use(cors({
+    origin: function(origin, callback){
+      if(!origin) return callback(null, true);
+      if(config.allowedOrigins.indexOf(origin) === -1){
+        var msg = 'The CORS policy for this site does not ' +
+                  'allow access from the specified Origin.';
+        return callback(new Error(msg), false);
+      }
+      return callback(null, true);
+    }
+  }));
   // Mount the client application.
   app.use('/', express.static(path.join(__dirname, '/client/dist')));
 


### PR DESCRIPTION
There were some problems with CORS headers. This commit should fix them.

Added a config in default.json "allowedOrigins". This array should contain the client app URL(s) allowed to access the application.

Also fixes the OPTIONS method request mentioned in #672

