### PR TITLE
Limit /access return data by project and form read access

### DIFF
--- a/src/middleware/accessHandler.js
+++ b/src/middleware/accessHandler.js
@@ -18,7 +18,7 @@ module.exports = function(router) {
     const userAccess = await promisify(router.formio.access.getAccess)(req, res);
 
     // Bail if the requester's roles don't have any overlap with general project-level read access
-    if (!_.intersection(userAccess.project.read_all, userAccess.roles).length) {
+    if (userAccess.project && !_.intersection(userAccess.project.read_all, userAccess.roles).length) {
       return res.status(200).json({roles: {}, forms: {}});
     }
 

--- a/src/middleware/accessHandler.js
+++ b/src/middleware/accessHandler.js
@@ -2,65 +2,85 @@
 /*eslint max-statements: 0*/
 
 /**
- * The Access handler returns all the access information for the forms and roles within the project.
+ * The Access handler returns access information for the forms and roles within the project.
+ *
+ * Results are limited according to the requesting user's access level.
  *
  * @param router
  */
 module.exports = function(router) {
   const hook = require('../util/hook')(router.formio);
-  return function accessHandler(req, res, next) {
+  const promisify = require('util').promisify;
+  const _ = require('lodash');
+
+  return async function accessHandler(req, res, next) {
+    // Fetch current user's access
+    const userAccess = await promisify(router.formio.access.getAccess)(req, res);
+
+    // Bail if the requester's roles don't have any overlap with general project-level read access
+    if (!_.intersection(userAccess.project.read_all, userAccess.roles).length) {
+      return res.status(200).json({roles: {}, forms: {}});
+    }
+
     // Load all the roles.
-    router.formio.resources.role.model.find(hook.alter('roleQuery', {deleted: {$eq: null}}, req))
-      .select({
-        title: 1,
-        admin: 1,
-        default: 1
-      })
-      .lean()
-      .exec(function(err, roleResult) {
-        if (err || !roleResult) {
-          return res.status(400).send('Could not load the Roles.');
+    const roles = {};
+
+    try {
+      const roleResult = await router.formio.resources.role.model
+        .find(hook.alter('roleQuery', {deleted: {$eq: null}}, req))
+        .select({title: 1, admin: 1, default: 1})
+        .lean()
+        .exec();
+
+      if (!roleResult) {
+        return res.status(400).send('Could not load the Roles.');
+      }
+
+      roleResult.forEach((role) => {
+        if (role.title) {
+          roles[role.title.replace(/\s/g, '').toLowerCase()] = role;
         }
-
-        const roles = {};
-        roleResult.forEach((role) => {
-          if (role.title) {
-            roles[role.title.replace(/\s/g, '').toLowerCase()] = role;
-          }
-        });
-
-        // Load all the forms.
-        router.formio.resources.form.model.find(hook.alter('formQuery', {deleted: {$eq: null}}, req))
-          .select({
-            title: 1,
-            name: 1,
-            path: 1,
-            access: 1,
-            submissionAccess: 1
-          })
-          .lean()
-          .exec(function(err, formResult) {
-            if (err || !formResult) {
-              return res.status(400).send('Could not load the Forms.');
-            }
-
-            const forms = {};
-            formResult.forEach(form => {
-              forms[form.name] = form;
-            });
-
-            // Allow other systems to add to the access information.
-            hook.alter('accessInfo', {
-              roles: roles,
-              forms: forms
-            }, function(err, accessInfo) {
-              if (err) {
-                return res.status(400).send(err.toString());
-              }
-
-              res.status(200).json(accessInfo);
-            });
-          });
       });
+    }
+    catch (err) {
+      return res.status(400).send('Could not load the Roles.');
+    }
+
+    // Load all the forms.
+    const forms = {};
+
+    try {
+      const formResult = await router.formio.resources.form.model
+        .find(hook.alter('formQuery', {deleted: {$eq: null}}, req))
+        .select({title: 1, name: 1, path: 1, access: 1, submissionAccess: 1})
+        .lean()
+        .exec();
+
+      if (!formResult) {
+        return res.status(400).send('Could not load the Forms.');
+      }
+
+      formResult.forEach(form => {
+        // Only include the form if the requester's roles have overlap with form definition read access roles
+        const formDefinitionAccess = form.access.find(perm => perm.type === 'read_all') || {};
+        const formDefinitionAccessRoles = (formDefinitionAccess.roles || []).map(id => id.toString());
+
+        if (_.intersection(userAccess.roles, formDefinitionAccessRoles).length) {
+          forms[form.name] = form;
+        }
+      });
+    }
+    catch (err) {
+      return res.status(400).send('Could not load the Forms.');
+    }
+
+    // Allow other systems to add to the access information.
+    try {
+      const accessInfo = await promisify(hook.alter)('accessInfo', {roles: roles, forms: forms});
+      res.status(200).json(accessInfo);
+    }
+    catch (err) {
+      return res.status(400).send(err.toString());
+    }
   };
 };

--- a/test/form.js
+++ b/test/form.js
@@ -4140,7 +4140,24 @@ module.exports = function(app, template, hook) {
     });
 
     describe('Access Information', function() {
-      it('Should be able to see the access for the forms and roles.', function(done) {
+      it('Authenticated users have appropriate form/role access visibility', function(done) {
+        request(app)
+          .get(hook.alter('url', '/access', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .expect('Content-Type', /json/)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            assert.equal(Object.keys(res.body.roles).length, 3);
+            assert.notEqual(res.body.forms.testComponentForm, undefined);
+            done();
+          });
+      });
+
+      it('Anonymous users have appropriate form/role access visibility', function(done) {
         request(app)
           .get(hook.alter('url', '/access', template))
           .expect('Content-Type', /json/)
@@ -4151,7 +4168,7 @@ module.exports = function(app, template, hook) {
             }
 
             assert.equal(Object.keys(res.body.roles).length, 3);
-            assert(Object.keys(res.body.forms).length > 3);
+            assert.equal(res.body.forms.testComponentForm, undefined);
             done();
           });
       });


### PR DESCRIPTION
Introduced user access retrieval as first step.

Forms are only returned if their configured `read_all` access roles overlap with the roles of the requesting user.

If project-level access denies `read_all` to the user, an empty result set is returned.

Refactored to replace nested callbacks with async/await.