### PR TITLE
[FOR-2492] Nicer response behavior for file component submission index endpoint

### DIFF
--- a/src/util/util.js
+++ b/src/util/util.js
@@ -543,8 +543,11 @@ const Utils = {
       }
       else if (component.type === 'file' && action === 'index') {
         modifyFields.push(((submission) => {
-          const data = _.get(submission, path);
-          _.set(submission, path, (!data || !data.length) ? '' : 'YES');
+          const data = _.map(
+            _.get(submission, path),
+            file => file.url.startsWith('data:') ? _.omit(file, 'url') : file
+          );
+          _.set(submission, path, data);
         }));
       }
     }, true);


### PR DESCRIPTION
#799 changed the behavior of the File component during `GET /.../submission` index queries to match the behavior of the Signature component: returning `"YES"` or `""` based on whether data exists. Submission-level queries were (and are) unaffected; they return the full file record.

This changes the behavior to be a fair bit nicer: it returns everything except the file's URL, and only in those cases where it is a data-URL.