### PR TITLE
Add minItems and maxItems validation

### DIFF
--- a/src/resources/Validator.js
+++ b/src/resources/Validator.js
@@ -789,8 +789,13 @@ class Validator {
         // throws an error on re-validation. Allowing null fixes the issue.
         fieldValidator = JoiX.array().sparse().items(fieldValidator.allow(null)).options({stripUnknown: false});
         // If a multi-value is required, make sure there is at least one.
-        if (component.validate && component.validate.required) {
+        if (component.validate && component.validate.required && !component.validate.minItems) {
           fieldValidator = fieldValidator.min(1).required();
+        } else if (component.validate.minItems) {
+          fieldValidator = fieldValidator.min(component.validate.minItems).required();
+        }
+        if (component.validate.maxItems) {
+          fieldValidator = fieldValidator.max(component.validate.maxItems);
         }
       }
 


### PR DESCRIPTION
Hi guys, I want to add a minItems and maxItems mainly to validate attachments. What do you think of adding this change?
Is this the right place to PR so the code gets into this image later https://cloud.docker.com/u/formio/repository/docker/formio/formio-enterprise ?

```js
{
  "autofocus": false,
  "input": true,
  "tableView": true,
  "label": "Test min-max",
  "key": "page1TestminMax",
  "image": true,
  "imageSize": "200",
  "placeholder": "",
  "multiple": true,
  "defaultValue": "",
  "protected": false,
  "persistent": true,
  "hidden": false,
  "filePattern": "*",
  "fileMinSize": "0KB",
  "fileMaxSize": "1GB",
  "type": "file",
  "storage": "s3",
  "slides": true,
  "labelPosition": "top",
  "tags": [],
  "conditional": {
      "show": "",
      "when": null,
      "eq": ""
  },
  "weight": 0,
  "properties": {},
  "validate": {
      **"minItems": 1,**
      **"maxItems": 5**
  },
  "clearOnHide": true
}     
``` 

Here is a postman test:
![Screenshot from 2019-10-04 18-37-12](https://user-images.githubusercontent.com/4873355/66241722-0b63f200-e6d6-11e9-8edb-5554347e76bf.png)


Id like to know if is possible to get the change into the backend server, thanks!