### PR TITLE
Fix Mongoose deprecation warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,6 +184,9 @@ module.exports = function(config) {
         mongoConfig.sslCA = config.mongoSA;
       }
 
+      mongoConfig.useUnifiedTopology = true;
+      mongoConfig.useCreateIndex = true;
+
       // Connect to MongoDB.
       mongoose.connect(mongoUrl, mongoConfig);
 

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -162,6 +162,8 @@ module.exports = function(formio) {
       mongoConfig.sslCA = config.mongoSA;
     }
 
+    mongoConfig.useUnifiedTopology = true;
+
     // Establish a connection and continue with execution.
     MongoClient.connect(dbUrl, mongoConfig, function(err, client) {
       if (err) {

--- a/src/models/Role.js
+++ b/src/models/Role.js
@@ -16,9 +16,8 @@ module.exports = function(formio) {
       required: true,
       validate: [
         {
-          isAsync: true,
           message: 'Role title must be unique.',
-          validator(value, done) {
+          async validator(value) {
             const search = hook.alter('roleSearch', {
               title: value,
               deleted: {$eq: null}
@@ -32,13 +31,13 @@ module.exports = function(formio) {
             }
 
             // Search for roles that exist, with the given parameters.
-            formio.mongoose.model('role').findOne(search, function(err, result) {
-              if (err || result) {
-                return done(false);
-              }
-
-              done(true);
-            });
+            try {
+              const result = await formio.mongoose.model('role').findOne(search).lean().exec();
+              return !result;
+            }
+            catch (err) {
+              return false;
+            }
           }
         }
       ]

--- a/src/models/Token.js
+++ b/src/models/Token.js
@@ -21,9 +21,8 @@ module.exports = function(formio) {
       }),
       validate: [
         {
-          isAsync: true,
           message: 'Token key must be unique.',
-          validator(key, done) {
+          async validator(key) {
             const search = hook.alter('tokenSearch', {key: key}, this, key);
 
             // Ignore the id of the token, if this is an update.
@@ -32,13 +31,13 @@ module.exports = function(formio) {
             }
 
             // Search for tokens that exist, with the given parameters.
-            formio.mongoose.model('token').findOne(search, function(err, result) {
-              if (err || result) {
-                return done(false);
-              }
-
-              done(true);
-            });
+            try {
+              const result = await formio.mongoose.model('token').findOne(search).lean().exec();
+              return !result;
+            }
+            catch (err) {
+              return false;
+            }
           }
         }
       ]


### PR DESCRIPTION
Fixes the three Mongoose deprecation warnings on startup:

- added `useUnifiedTopology: true` to connection options
- added `useCreateIndex: true` to connection options
- converted done-style async model validators to use promises, allowing us to remove the deprecated `isAsync: true` flag on associated fields
