### PR TITLE
Fix URL to download Github archives

### DIFF
--- a/install.js
+++ b/install.js
@@ -243,7 +243,7 @@ module.exports = function(formio, items, done) {
 
       // Download the app.
       download(
-        `https://nodeload.github.com/${application}/zip/master`,
+        `https://codeload.github.com/${application}/zip/master`,
         'app.zip',
         'app',
         done
@@ -279,7 +279,7 @@ module.exports = function(formio, items, done) {
 
       // Download the client.
       download(
-        'https://nodeload.github.com/formio/formio-app-formio/zip/master',
+        'https://codeload.github.com/formio/formio-app-formio/zip/master',
         'client.zip',
         'client',
         done


### PR DESCRIPTION
During installation, the client is downloaded from Github repositories. `install.js` uses an outdated archive link `https://nodeload.github.com`, but Github now serves archives on `https://codeload.github.com`.

A better solution would be to ask the Github API for a link to the archives, as documented here: https://developer.github.com/v3/repos/contents/#get-archive-link

This fixes #583.