### PR TITLE
fixed temp token check generated with admin key

### DIFF
--- a/src/export/export.js
+++ b/src/export/export.js
@@ -23,7 +23,7 @@ module.exports = (router) => {
 
   // Mount the export endpoint using the url.
   router.get('/form/:formId/export', (req, res, next) => {
-    if (!_.has(req, 'token') || !_.has(req, 'token.user._id')) {
+    if (!_.get(req, 'token.isAdmin', false) && !_.has(req, 'token.user._id')) {
       return res.sendStatus(400);
     }
 

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -23,7 +23,7 @@ module.exports = (router) => {
 
   // Mount the export endpoint using the url.
   router.get('/form/:formId/export', (req, res, next) => {
-    if (!_.get(req, 'token.isAdmin', false) && !_.has(req, 'token.user._id')) {
+    if (!req.isAdmin && !_.has(req, 'token.user._id')) {
       return res.sendStatus(400);
     }
 


### PR DESCRIPTION
Temp token generated using the x-admin-key header returns a temp token without user.  The export endpoint fails with status code 400 if no user id is set int he token.  This fixes the token validation check so that it accepts temp tokens generated with the admin key.