### PR TITLE
Pin version of base docker image, use node:lts-alpine3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 # Use Node image, maintained by Docker:
 # hub.docker.com/r/_/node/
-FROM node:lts-alpine
+FROM node:lts-alpine3.10
 WORKDIR /app
 
 # "bcrypt" requires python/make/g++, all must be installed in alpine


### PR DESCRIPTION
Hi,

I noticed the tag `node:lts-alpine` has been updated and now points to 3.11, this causes the build to fail since the version of python2.7 and g++ have changed.

```
...
Step 3/11 : RUN apk update &&     apk upgrade &&     apk add python=2.7.16-r1 &&     apk add make=4.2.1-r2 &&     apk add g++=8.3.0-r0
 ---> Running in c72802b5a194
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/community/x86_64/APKINDEX.tar.gz
v3.11.2-31-g433facdd60 [http://dl-cdn.alpinelinux.org/alpine/v3.11/main]
v3.11.2-32-g587f005260 [http://dl-cdn.alpinelinux.org/alpine/v3.11/community]
OK: 11261 distinct packages available
(1/2) Upgrading libcrypto1.1 (1.1.1d-r2 -> 1.1.1d-r3)
(2/2) Upgrading libssl1.1 (1.1.1d-r2 -> 1.1.1d-r3)
OK: 7 MiB in 16 packages
ERROR: unsatisfiable constraints:
  python2-2.7.16-r3:
    breaks: world[python=2.7.16-r1]
ERROR: Service 'formio' failed to build: The command '/bin/sh -c apk update &&     apk upgrade &&     apk add python=2.7.16-r1 &&     apk add make=4.2.1-r2 &&     apk add g++=8.3.0-r0' returned a non-zero code: 1
```

We can either pin the version of the docker image to `lts-alpine3.10` (done in this PR).
Or update the version of the depedencies installed here https://github.com/formio/formio/blob/master/Dockerfile#L14
