### PR TITLE
Added editgrid to CSV exporter ignore list

### DIFF
--- a/src/export/exporters/CSVExporter.js
+++ b/src/export/exporters/CSVExporter.js
@@ -43,7 +43,7 @@ class CSVExporter extends Exporter {
     const formattedView = req.query.view === 'formatted';
     this.formattedView = formattedView;
 
-    const ignore = ['password', 'button', 'container', 'datagrid'];
+    const ignore = ['password', 'button', 'container', 'datagrid', 'editgrid'];
     try {
       util.eachComponent(form.components, (component, path) => {
         if (!component.input || !component.key || ignore.includes(component.type)) {


### PR DESCRIPTION
This is a small fix in the CSV exporter.  Added `editgrid` component to ignore list as we only want the components row data.

Fixes the edit grid portion in issue https://github.com/formio/formio/issues/980
