### PR TITLE
fix: allow Docker to load git npm paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,12 @@ RUN apk update && \
     apk add make=4.2.1-r2 && \
     apk add g++=8.3.0-r0
 
+# At least one buried package dependency is using a `git` path.
+# Hence we need to haul in git.
+RUN apk --update add git
+# Use https to avoid requiring ssh keys for public repos.
+RUN git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+
 # Using an alternative package install location
 # to allow overwriting the /app folder at runtime
 # stackoverflow.com/a/13021677
@@ -28,6 +34,8 @@ COPY ./package-lock.json $NPM_PACKAGES/
 
 # Use "Continuous Integration" to install as-is from package-lock.json
 RUN npm ci --prefix=$NPM_PACKAGES
+
+RUN apk del git
 
 # Link in the global install because `require()` only looks for ./node_modules
 # WARNING: This is overwritten by volume-mount at runtime!


### PR DESCRIPTION
I had trouble with the Docker build.  It looks like a couple weeks ago someone changed `formio.js`'s package.json file to load `text-mask` from a git path.  Since `git` isn't part of the `alpine` Docker container this container's build fails.