### PR TITLE
Unhid block component label in webhook action settings form

### DIFF
--- a/src/actions/WebhookAction.js
+++ b/src/actions/WebhookAction.js
@@ -62,7 +62,7 @@ module.exports = function(router) {
           defaultValue: false,
           key: 'block',
           label: 'Block request for Webhook feedback',
-          hideLabel: true,
+          hideLabel: false,
           tableView: true,
           inputType: 'checkbox',
           input: true


### PR DESCRIPTION
After accidentally blocking myself while testing the webhook action in the admin login form, I thought it should be a good idea to show users what actually checking an unknown checkbox do. 
