### PR TITLE
FIO-3223: Fixes an error with out of memory

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const Q = require('q');
 const nunjucks = require('nunjucks');
 const util = require('./src/util/util');
 const log = require('debug')('formio:log');
+const gc = require('expose-gc/function');
 
 const originalGetToken = util.Formio.getToken;
 const originalEvalContext = util.Formio.Components.components.component.prototype.evalContext;
@@ -109,6 +110,19 @@ module.exports = function(config) {
         };
         util.Formio.getToken = originalGetToken;
         util.Formio.Components.components.component.prototype.evalContext = originalEvalContext;
+
+        try {
+          if (config.maxOldSpace) {
+            const heap = process.memoryUsage().heapTotal / 1024 / 1024;
+
+            if ((config.maxOldSpace * 0.8) < heap) {
+              gc();
+            }
+          }
+        }
+        catch (error) {
+          console.log(error);
+        }
 
         next();
       });

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "delete-property": "0.0.4",
     "eslint-config-formio": "^1.1.2",
     "event-chain": "^0.0.1",
+    "expose-gc": "^1.0.0",
     "express": "^4.17.1",
     "fast-json-patch": "^2.2.1",
     "formio-workers": "^1.14.13",

--- a/src/actions/SaveSubmission.js
+++ b/src/actions/SaveSubmission.js
@@ -206,15 +206,13 @@ module.exports = function(router) {
           try {
             let vm = new VM({
               timeout: 500,
-              sandbox: {},
+              sandbox: {
+                submission: (res.resource && res.resource.item) ? res.resource.item : req.body,
+                data: submission.data,
+              },
               eval: false,
               fixAsync: true
             });
-
-            const vmSubmission = (res.resource && res.resource.item) ? res.resource.item : req.body;
-
-            vm.freeze(vmSubmission, 'submission');
-            vm.freeze(submission.data, 'data');
 
             const newData = vm.run(this.settings.transform);
             submission.data = newData;

--- a/src/actions/SaveSubmission.js
+++ b/src/actions/SaveSubmission.js
@@ -204,16 +204,21 @@ module.exports = function(router) {
 
         if (this.settings.transform) {
           try {
-            const newData = (new VM({
+            let vm = new VM({
               timeout: 500,
-              sandbox: _.cloneDeep({
-                submission: (res.resource && res.resource.item) ? res.resource.item : req.body,
-                data: submission.data,
-              }),
+              sandbox: {},
               eval: false,
               fixAsync: true
-            })).run(this.settings.transform);
+            });
+
+            const vmSubmission = (res.resource && res.resource.item) ? res.resource.item : req.body;
+
+            vm.freeze(vmSubmission, 'submission');
+            vm.freeze(submission.data, 'data');
+
+            const newData = vm.run(this.settings.transform);
             submission.data = newData;
+            vm = null;
           }
           catch (err) {
             debug(`Error in submission transform: ${err.message}`);

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -308,21 +308,21 @@ module.exports = (router) => {
 
           let vm = new VM({
             timeout: 500,
-            sandbox: _.cloneDeep({
+            sandbox: {
               execute: params.execute,
               query: params.query,
-            }),
+              data: params.data,
+              form: params.form,
+              submission: params.body,
+              previous: params.previousSubmission,
+            },
             eval: false,
             fixAsync: true
           });
 
           vm.freeze(params.jsonLogic, 'jsonLogic');
-          vm.freeze(params.data, 'data');
-          vm.freeze(params.form, 'form');
           vm.freeze(params.FormioUtils, 'util');
           vm.freeze(params.moment, 'moment');
-          vm.freeze(params.body, 'submission');
-          vm.freeze(params.previousSubmission, 'previous');
           vm.freeze(params._, '_');
 
           const result = vm.run(json ?

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -293,26 +293,46 @@ module.exports = (router) => {
         }
 
         try {
-          return (new VM({
+          const params = await hook.alter('actionContext', {
+            jsonLogic: util.FormioUtils.jsonLogic,
+            data: req.body.data,
+            form: req.form,
+            query: req.query,
+            util: util.FormioUtils,
+            moment: moment,
+            submission: req.body,
+            previous: req.previousSubmission,
+            execute: false,
+            _
+          }, req);
+
+          let vm = new VM({
             timeout: 500,
-            sandbox: _.cloneDeep(await hook.alter('actionContext', {
-              jsonLogic: util.FormioUtils.jsonLogic,
-              data: req.body.data,
-              form: req.form,
-              query: req.query,
-              util: util.FormioUtils,
-              moment: moment,
-              submission: req.body,
-              previous: req.previousSubmission,
-              execute: false,
-              _
-            }, req)),
+            sandbox: _.cloneDeep({
+              execute: params.execute,
+              query: params.query,
+            }),
             eval: false,
             fixAsync: true
-          })).run(json ?
+          });
+
+          vm.freeze(params.jsonLogic, 'jsonLogic');
+          vm.freeze(params.data, 'data');
+          vm.freeze(params.form, 'form');
+          vm.freeze(params.FormioUtils, 'util');
+          vm.freeze(params.moment, 'moment');
+          vm.freeze(params.body, 'submission');
+          vm.freeze(params.previousSubmission, 'previous');
+          vm.freeze(params._, '_');
+
+          const result = vm.run(json ?
             `execute = jsonLogic.apply(${condition.custom}, { data, form, _, util })` :
             condition.custom
           );
+
+          vm = null;
+
+          return result;
         }
         catch (err) {
           router.formio.log(

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -52,9 +52,9 @@ Formio.Utils.Evaluator.evaluator = function(func, args) {
     try {
       let vm = new VM({
         timeout: 250,
-        sandbox: _.cloneDeep({
+        sandbox: {
           result: null,
-        }),
+        },
         fixAsync: true
       });
 

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -50,14 +50,19 @@ Formio.Utils.Evaluator.evaluator = function(func, args) {
     let result = null;
     /* eslint-disable no-empty */
     try {
-      result = (new VM({
+      let vm = new VM({
         timeout: 250,
         sandbox: _.cloneDeep({
           result: null,
-          args
         }),
         fixAsync: true
-      })).run(`result = (function({${_.keys(args).join(',')}}) {${func}})(args);`);
+      });
+
+      vm.freeze(args, 'args');
+
+      result = vm.run(`result = (function({${_.keys(args).join(',')}}) {${func}})(args);`);
+
+      vm = null;
     }
     catch (err) {}
     /* eslint-enable no-empty */


### PR DESCRIPTION
- Replaced cloneDeep to freeze for VM to increase speed and decrease memory usage.

- Added a GC force middleware to prevent out-of-memory error.

Related PR https://github.com/formio/formio-server/pull/847