### PR TITLE
Added public config support

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,6 +197,11 @@ module.exports = function(config) {
         router.get('/access', router.formio.middleware.accessHandler);
       }
 
+      // The public config handler.
+      if (!router.formio.hook.invoke('init', 'config', router.formio)) {
+        router.use('/config.json', router.formio.middleware.configHandler);
+      }
+
       // Authorize all urls based on roles and permissions.
       if (!router.formio.hook.invoke('init', 'perms', router.formio)) {
         router.use(router.formio.middleware.permissionHandler);

--- a/src/middleware/alias.js
+++ b/src/middleware/alias.js
@@ -44,7 +44,7 @@ module.exports = function(router) {
 
     // If this is normal request, then pass this middleware.
     /* eslint-disable no-useless-escape */
-    if (!alias || alias.match(/^(form$|form[\?\/])/) || alias === 'spec.json') {
+    if (!alias || alias.match(/^(form$|form[\?\/])/) || alias === 'spec.json' || alias ===  'config.json') {
       return next();
     }
     /* eslint-enable no-useless-escape */

--- a/src/middleware/configHandler.js
+++ b/src/middleware/configHandler.js
@@ -1,0 +1,37 @@
+'use strict';
+const debug = require('debug')('formio:config');
+const _ = require('lodash');
+
+/**
+ * The Config handler returns the project's public configuration.
+ *
+ * @param router
+ */
+module.exports = function(router) {
+  const hook = require('../util/hook')(router.formio);
+  const formio = hook.alter('formio', router.formio);
+  const config = {};
+
+  if (_.isPlainObject(formio.config.public)) {
+    _.forOwn(formio.config.public, (value, key) => {
+      config[key] = value;
+    });
+  }
+
+  // Allow the PUBLIC_CONFIG variable define or overwrite the default public configuration.
+  if (process.env.PUBLIC_CONFIG) {
+    try {
+      _.forOwn(JSON.parse(process.env.PUBLIC_CONFIG), (value, key) => {
+        config[key] = value;
+      });
+    }
+    catch (err) {
+      debug('Failed to parse public configuration.');
+      debug(err);
+    }
+  }
+
+  return function configHandler(req, res, next) {
+    return res.json({config});
+  };
+};

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -12,6 +12,7 @@ module.exports = function(router) {
     bootstrapSubmissionAccess: require('./bootstrapSubmissionAccess')(router),
     condensePermissionTypes: require('./condensePermissionTypes')(router),
     condenseSubmissionPermissionTypes: require('./condenseSubmissionPermissionTypes')(router),
+    configHandler: require('./configHandler')(router),
     filterIdCreate: require('./filterIdCreate')(router),
     filterMongooseExists: require('./filterMongooseExists')(router),
     filterResourcejsResponse: require('./filterResourcejsResponse')(router),


### PR DESCRIPTION
In order to allow extra compatibility with the enterprise server, I have added the public configuration endpoint.

The public configuration can be added through the `config/default.json` file under the `public` key:

```json
{
...
  "public": {
    "foo": "bar"
  }
}
```

The public configuration can also be defined through environment variable under the key `PUBLIC_CONFIG` using a JSON string.

```bash
export PUBLIC_CONFIG='{"foo":"bar"}'
npm start
```