### PR TITLE
Quick fix to point the issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const nunjucks = require('nunjucks');
 const util = require('./src/util/util');
 const log = require('debug')('formio:log');
 const gc = require('expose-gc/function');
+const fs = require('fs');
 
 const originalGetToken = util.Formio.getToken;
 const originalEvalContext = util.Formio.Components.components.component.prototype.evalContext;
@@ -226,6 +227,7 @@ module.exports = function(config) {
       if (config.mongoSA || config.mongoCA) {
         mongoConfig.sslValidate = true;
         mongoConfig.sslCA = config.mongoSA || config.mongoCA;
+        mongoConfig.sslCA = fs.readFileSync(mongoConfig.sslCA);
       }
 
       mongoConfig.useUnifiedTopology = true;


### PR DESCRIPTION
Seems like there is some kind of incompatibility between Mongoose and MongoDB driver. While the latest versions of MongoDB driver are using file path to read ssl certificates, Mongoose requires the contents of the certificate. This path fixes code working with Mongoose to use the contents of the certificate.