### PR TITLE
fix docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,27 +20,12 @@ RUN apk --update add git
 # Use https to avoid requiring ssh keys for public repos.
 RUN git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
 
-# Using an alternative package install location
-# to allow overwriting the /app folder at runtime
-# stackoverflow.com/a/13021677
-ENV NPM_PACKAGES=/.npm-packages \
-    PATH=$NPM_PACKAGES/bin:$PATH \
-    NODE_PATH=$NPM_PACKAGES/lib/node_modules:$NODE_PATH
-RUN echo "prefix = $NPM_PACKAGES" >> ~/.npmrc
-
-# Include details of the required dependencies
-COPY ./package.json $NPM_PACKAGES/
-COPY ./package-lock.json $NPM_PACKAGES/
+COPY . .
 
 # Use "Continuous Integration" to install as-is from package-lock.json
-RUN npm ci --prefix=$NPM_PACKAGES
+RUN npm ci
 
 RUN apk del git
-
-# Link in the global install because `require()` only looks for ./node_modules
-# WARNING: This is overwritten by volume-mount at runtime!
-#          See docker-compose.yml for instructions
-RUN ln -sf $NPM_PACKAGES/node_modules node_modules
 
 # Set this to inspect more from the application. Examples:
 #   DEBUG=formio:db (see index.js for more)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,10 +32,6 @@ services:
       - mongo
     ports:
       - "3001:3001"
-    # The application wants to download things to the local directory
-    # TODO: really wish I could mount this as read-only
-    volumes:
-      - ./:/app:rw
     environment:
       DEBUG: formio:*
       NODE_CONFIG: '{"mongo": "mongodb://mongo:27017/formio"}'


### PR DESCRIPTION
I suggest simplifying the Docker build and not mounting the host system at all. I added a dockerignore file to ignore some folders on the host system and during the build of the image I copy everything except the ignored folders to the image and then run npm ci to install everything.

I am not sure what the client folder was for, but if we need to persist it, we should either install it as a part of the build or create a separate volume for it.