### PR TITLE
FIO 5911: Email action no longer naively sends any PDF server response as PDF attachment

### DIFF
--- a/src/actions/EmailAction.js
+++ b/src/actions/EmailAction.js
@@ -263,7 +263,7 @@ module.exports = (router) => {
                   else {
                     setActionItemMessage('Message Sent');
                   }
-                });
+                }, setActionItemMessage);
               });
           })
           .catch((err) => {

--- a/src/util/email.js
+++ b/src/util/email.js
@@ -225,7 +225,7 @@ module.exports = (formio) => {
    * @param next
    * @returns {*}
    */
-  const send = (req, res, message, params, next) => {
+  const send = (req, res, message, params, next, setActionItemMessage = () => {}) => {
     // The transporter object.
     let transporter = {sendMail: null};
 
@@ -490,7 +490,7 @@ module.exports = (formio) => {
                 reject(err);
               }
             });
-          });
+          }, setActionItemMessage);
         });
       };
 


### PR DESCRIPTION
Previously, it was possible for the PDF server to return a non-200 response (or for the download PDF middleware to throw an error) during the PDF submission attachment process in the email action and for this response to get bundled as base64 and attached to the resulting email. This PR replaces this behavior by passing a potential setActionItemMessage method (which defaults to a noop for open source) down the callback chain so it is accessible during the PDF attachment process.