### PR TITLE
FIO-5911: update email action steps

### DIFF
--- a/src/actions/EmailAction.js
+++ b/src/actions/EmailAction.js
@@ -263,7 +263,7 @@ module.exports = (router) => {
                   else {
                     setActionItemMessage('Message Sent');
                   }
-                });
+                }, setActionItemMessage);
               });
           })
           .catch((err) => {

--- a/src/util/email.js
+++ b/src/util/email.js
@@ -225,7 +225,7 @@ module.exports = (formio) => {
    * @param next
    * @returns {*}
    */
-  const send = (req, res, message, params, next) => {
+  const send = (req, res, message, params, next, setActionItemMessage = () => {}) => {
     // The transporter object.
     let transporter = {sendMail: null};
 
@@ -461,7 +461,7 @@ module.exports = (formio) => {
 
         return new Promise((resolve, reject) => {
           // Allow anyone to hook the final email before sending.
-          return hook.alter('email', email, req, res, params, (err, email) => {
+          return hook.alter('email', email, req, res, params, setActionItemMessage, (err, email) => {
             if (err) {
               return reject(err);
             }
@@ -524,26 +524,26 @@ module.exports = (formio) => {
               );
             }));
           }, Promise.resolve());
-        });
+      });
 
-        const throttledSendEmails = _.throttle(sendEmails , NON_PRIORITY_QUEUE_TIMEOUT);
+      const throttledSendEmails = _.throttle(sendEmails , NON_PRIORITY_QUEUE_TIMEOUT);
 
-        if (req.user) {
-          return sendEmails()
-            .then((response) => next(null, response))
-            .catch((err) => {
-              debug.error(err);
-              return next(err);
-            });
-        }
-     else {
-      throttledSendEmails()
-        .catch((err) => {
-          debug.error(err);
-          return next(err);
-        });
+      if (req.user) {
+        return sendEmails()
+          .then((response) => next(null, response))
+          .catch((err) => {
+            debug.error(err);
+            return next(err);
+          });
+      }
+      else {
+        throttledSendEmails()
+          .catch((err) => {
+            debug.error(err);
+            return next(err);
+          });
         return next();
-     }
+      }
     });
   };
 


### PR DESCRIPTION
Previously, it was possible for the PDF server to return a non-200 response (or for the download PDF middleware to throw an error) during the PDF submission attachment process in the email action and for this response to get bundled as base64 and attached to the resulting email. This PR replaces this behavior by passing a potential setActionItemMessage method (which defaults to a noop for open source) down the callback chain so it is accessible during the PDF attachment process.