### PR TITLE
Add logging and header for custom conditions within actions

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -307,6 +307,7 @@ module.exports = (router) => {
             data: isDelete ? _.get(deletedSubmission, `data`, {}) : req.body.data,
             form: req.form,
             query: req.query,
+            headers: req.headers,
             util: util.FormioUtils,
             moment: moment,
             submission: isDelete ? deletedSubmission : req.body,
@@ -322,6 +323,7 @@ module.exports = (router) => {
               query: params.query,
               data: params.data,
               form: params.form,
+              headers: params.headers,
               submission: params.submission,
               previous: params.previous,
             },
@@ -333,6 +335,10 @@ module.exports = (router) => {
           vm.freeze(params.FormioUtils, 'util');
           vm.freeze(params.moment, 'moment');
           vm.freeze(params._, '_');
+
+          vm.on('console.log', (logData) => {
+            this.updateActionItem(req, action,'VM Log Messages', logData, 'log');
+          });
 
           const result = vm.run(json ?
             `execute = jsonLogic.apply(${condition.custom}, { data, form, _, util })` :

--- a/test/actions.js
+++ b/test/actions.js
@@ -3115,6 +3115,21 @@ module.exports = (app, template, hook) => {
               role: 'authenticated',
             },
           })
+          .action({
+            title: 'IP Address Checking',
+            name: 'role',
+            priority: 1,
+            handler: ['after'],
+            method: ['create'],
+            condition: {
+              custom: 'execute = (header.Get("X-Forwarded-For") == "127.0.0.1")',
+            },
+            settings: {
+              association: 'new',
+              type: 'add',
+              role: 'authenticated',
+            },
+          })
           .execute(done);
       });
 


### PR DESCRIPTION
When creating custom conditions, it would be good to be able to log information and inspect the HTTP headers.

![image](https://user-images.githubusercontent.com/22875/211999813-ca2ee273-1e31-4eb0-9bc1-e8ad0596fa62.png)


* Headers to allow access to custom information that can be added by network tools; and 
* Logging to allow developers to inspect what objects are available during the request.