### PR TITLE
upgrade jsonwebtoken dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "formiojs": "^4.15.0-rc.7",
     "fs-extra": "^10.1.0",
     "html-entities": "^2.3.3",
-    "jsonwebtoken": "^8.5.1",
+    "jsonwebtoken": "^9.0.0",
     "lodash": "^4.17.21",
     "mailgun.js": "^8.0.1",
     "memory-cache": "^0.2.0",


### PR DESCRIPTION
Breaking changes are:
* no more support for Node versions 11 and below (should be fine here, although I'm not sure where/if we document our Node version support)
* the verify() function no longer accepts unsigned tokens by default (should be fine here unless the user has explicitly deleted the jwt secret in their config)
* RSA key size must be 2048 bits or greater (should be fine here)