### PR TITLE
FIO 6579 - legacy templates

### DIFF
--- a/src/templates/import.js
+++ b/src/templates/import.js
@@ -163,7 +163,7 @@ module.exports = (router) => {
         }
         else if (template.forms[formName].revisions) {
             const revisionId = entity.revision;
-            const revisionTemplate = template.revisions[`${formName}:${revisionId}`];
+            const revisionTemplate = template.revisions && template.revisions[`${formName}:${revisionId}`];
             const revision = revisionTemplate && revisionTemplate.newId ? revisionTemplate.newId
             : getFormRevision(template.forms[formName]._vid);
             updateRevisionProperty(entity, revision);


### PR DESCRIPTION
It looks like there was another problematic object accessor, similar to #1543 - this time it wasn't identified by a customer error, but by odd test behavior from the enterprise test suite