### PR TITLE
FIO-4216 | FIO-6601 - Fixes no custom submission collection lookup when getting submissions

### DIFF
--- a/src/actions/properties/reference.js
+++ b/src/actions/properties/reference.js
@@ -208,7 +208,7 @@ module.exports = (router) => {
           resolve(form);
         })
       );
-      // Get the subquery.
+      // Get the subquery.//
       const subQuery = getSubQuery(formId, req.query, path);
       const subQueryReq = {query: subQuery.match};
       const subFindQuery = router.formio.resources.submission.getFindQuery(subQueryReq);

--- a/src/actions/properties/reference.js
+++ b/src/actions/properties/reference.js
@@ -198,9 +198,16 @@ module.exports = (router) => {
   // Build a pipeline to load all references within an index.
   const buildPipeline = function(component, path, req, res) {
     // First check their access within this form.
-    return checkAccess(component, req.query, req, res).then(() => {
+    return checkAccess(component, req.query, req, res).then(async () => {
       const formId = component.form || component.resource || component.data.resource;
-
+      const form = await new Promise((resolve, reject) =>
+        router.formio.cache.loadForm(req, null, formId, (err, form) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(form);
+        })
+      );
       // Get the subquery.
       const subQuery = getSubQuery(formId, req.query, path);
       const subQueryReq = {query: subQuery.match};
@@ -208,11 +215,13 @@ module.exports = (router) => {
 
       // Create the pipeline for this component.
       let pipeline = [];
-
+      const submissionsCollectionName = form.settings && form.settings.collection
+        ? `${req.currentProject.name.replace(/[^A-Za-z0-9]+/g, '')}_${form.settings.collection.replace(/[^A-Za-z0-9]+/g, '')}`
+        : 'submissions';
       // Load the reference.
       pipeline.push({
         $lookup: {
-          from: 'submissions',
+          from: submissionsCollectionName,
           localField: `data.${path}._id`,
           foreignField: '_id',
           as: `data.${path}`
@@ -244,24 +253,17 @@ module.exports = (router) => {
       }
 
       return new Promise((resolve, reject) => {
-        // Load the form.
-        router.formio.cache.loadForm(req, null, formId, function(err, form) {
-          if (err) {
-            return reject(err);
+        // Build the pipeline for the subdata.
+        var queues = [];
+        util.FormioUtils.eachComponent(form.components, (subcomp, subpath) => {
+          if (subcomp.reference) {
+            queues.push(buildPipeline(subcomp, `${path}.data.${subpath}`, req, res).then((subpipe) => {
+              pipeline = pipeline.concat(subpipe);
+            }));
           }
-
-          // Build the pipeline for the subdata.
-          var queues = [];
-          util.FormioUtils.eachComponent(form.components, (subcomp, subpath) => {
-            if (subcomp.reference) {
-              queues.push(buildPipeline(subcomp, `${path}.data.${subpath}`, req, res).then((subpipe) => {
-                pipeline = pipeline.concat(subpipe);
-              }));
-            }
-          });
-
-          Promise.all(queues).then(() => resolve(pipeline)).catch((err) => reject(err));
         });
+
+        Promise.all(queues).then(() => resolve(pipeline)).catch((err) => reject(err));
       });
     });
   };

--- a/src/middleware/filterMongooseExists.js
+++ b/src/middleware/filterMongooseExists.js
@@ -33,10 +33,12 @@ module.exports = (router) => (settings) => function(req, res, next) {
     query[settings.field] = exists;
   }
 
-  req.modelQuery = req.modelQuery || req.model || this.model;
+  req.modelQuery = req.modelQuery || req.model ||
+    (req.path.includes('/submission') && req.submissionModel) || this.model;
   req.modelQuery = req.modelQuery.find(query);
 
-  req.countQuery = req.countQuery || req.model || this.model;
+  req.countQuery = req.countQuery || req.model ||
+    (req.path.includes('/submission') && req.submissionModel) || this.model;
   req.countQuery = req.countQuery.find(query);
 
   next();

--- a/test/submission.js
+++ b/test/submission.js
@@ -34,6 +34,231 @@ module.exports = function(app, template, hook) {
       helper.project().user('user', 'user1').execute(done);
     });
 
+    if (app.hasProjects || docker)
+    describe('Submissions Collection', () => {
+      const test = require('./fixtures/forms/singlecomponents1.js');
+
+      before(done => {
+        process.env.TEST_SIMULATE_SAC_PACKAGE = '1';
+        process.env.API_KEYS = '123testing123testing';
+
+        // Update project to be commercial and have API key set up in settings
+        request(app)
+          .put(`/project/${helper.template.project._id}`)
+          .set('x-jwt-token', template.formio.owner.token)
+          .send({
+            plan: 'commercial',
+            settings: {
+              keys: [
+                {
+                  name: 'Test Key',
+                  key: '123testing123testing',
+                },
+              ]
+            }
+          })
+          .expect(200)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            const updatedProject = res.body;
+
+            assert.equal(updatedProject._id, helper.template.project._id);
+            assert.equal(updatedProject.plan, 'commercial');
+            assert.deepEqual(updatedProject.settings.keys, [
+              {
+                name: 'Test Key',
+                key: '123testing123testing',
+              },
+            ]);
+
+            helper.template.project = updatedProject;
+
+            done();
+          });
+      });
+
+      it('Should get the submission from separate mongo collection with api key', async () => {
+        // Create form with custom submissions collection
+        const collectionName = chance.word();
+        const formCreateRes = await request(app)
+          .post(`/project/${helper.template.project._id}/form`)
+          .set('x-jwt-token', template.formio.owner.token)
+          .send({
+            title: chance.word(),
+            name: chance.word(),
+            path: chance.word(),
+            type: 'form',
+            components: test.components,
+            settings: {
+              collection: collectionName
+            }
+          });
+
+        const createdForm = formCreateRes.body;
+
+        assert.ok(createdForm._id);
+        assert.equal(createdForm.project, helper.template.project._id);
+        assert.equal(createdForm.settings.collection, collectionName);
+
+        // Create form submission
+        const submissionCreateRes = await request(app)
+          .post(`/project/${helper.template.project._id}/form/${createdForm._id}/submission`)
+          .set('x-jwt-token', template.formio.owner.token)
+          .send({
+            data: test.submission
+          });
+
+        const createdSubmission = submissionCreateRes.body;
+
+        assert.ok(createdSubmission._id);
+        assert.equal(createdSubmission.form, createdForm._id);
+        assert.deepEqual(createdSubmission.data, test.submission);
+
+        // Try to get created submission with API key
+        const submissionRes = await request(app)
+          .get(`/project/${helper.template.project._id}/form/${createdForm._id}/submission/${createdSubmission._id}`)
+          .set('x-token', '123testing123testing');
+
+        const submission = submissionRes.body;
+
+        assert.equal(createdSubmission._id, submission._id);
+        assert.deepEqual(submission.data, test.submission);
+      });
+
+      it('Should retrieve submissions for form with Select component with reference to a form with custom submissions collection', async () => {
+        const textFieldComponent = test.components.find(comp => comp.type === 'textfield');
+        const textFieldComponentSubmission = test.submission[textFieldComponent.key];
+
+        // Create resource with Text Field and assign custom submissions collection in settings
+        const collectionName = chance.word();
+        const resourceCreateRes = await request(app)
+          .post(`/project/${helper.template.project._id}/form`)
+          .set('x-jwt-token', template.formio.owner.token)
+          .send({
+            title: chance.word(),
+            name: chance.word(),
+            path: chance.word(),
+            type: 'resource',
+            components: [textFieldComponent],
+            settings: {
+              collection: collectionName
+            }
+          });
+
+        const createdResource = resourceCreateRes.body;
+
+        assert.ok(createdResource._id);
+        assert.equal(createdResource.project, helper.template.project._id);
+        assert.equal(createdResource.components[0].key, textFieldComponent.key);
+        assert.equal(createdResource.settings.collection, collectionName);
+
+        // Create resource submission
+        const resourceSubmissionCreateRes = await request(app)
+          .post(`/project/${helper.template.project._id}/form/${createdResource._id}/submission`)
+          .set('x-jwt-token', template.formio.owner.token)
+          .send({
+            data: { [textFieldComponent.key]: textFieldComponentSubmission }
+          });
+
+        const resourceSubmission = resourceSubmissionCreateRes.body;
+
+        assert.ok(resourceSubmission._id);
+        assert.equal(resourceSubmission.form, createdResource._id);
+        assert.deepEqual(resourceSubmission.data, { [textFieldComponent.key]: textFieldComponentSubmission });
+
+        const selectComponent = test.components.find(comp => comp.type === 'select');
+
+        // Set up Select component to use the created resource
+        selectComponent.data = {
+          resource: createdResource._id
+        };
+        selectComponent.dataSrc = 'resource';
+        selectComponent.template = `<span>{{ item.data.${textFieldComponent.key} }}</span>`;
+        selectComponent.reference = true;
+
+        // Create form with Select component
+        const formCreateRes = await request(app)
+          .post(`/project/${helper.template.project._id}/form`)
+          .set('x-jwt-token', template.formio.owner.token)
+          .send({
+            title: chance.word(),
+            name: chance.word(),
+            path: chance.word(),
+            type: 'form',
+            components: [selectComponent]
+          });
+
+        const createdForm = formCreateRes.body;
+
+        assert.ok(createdForm._id);
+        assert.equal(createdForm.project, helper.template.project._id);
+        assert.equal(createdForm.components[0].key, selectComponent.key);
+        assert.equal(createdForm.components[0].data.resource, createdResource._id);
+
+        // Create form submission
+        const formSubmissionCreateRes = await request(app)
+          .post(`/project/${helper.template.project._id}/form/${createdForm._id}/submission`)
+          .set('x-jwt-token', template.formio.owner.token)
+          .send({
+            data: { [selectComponent.key]: resourceSubmission }
+          });
+
+        const formSubmission = formSubmissionCreateRes.body;
+
+        assert.ok(formSubmission._id);
+        assert.equal(formSubmission.form, createdForm._id);
+        assert.deepEqual(formSubmission.data, { [selectComponent.key]: resourceSubmission });
+
+        // Try to get form submissions
+        const formSubmissionsRes = await request(app)
+          .get(`/project/${helper.template.project._id}/form/${createdForm._id}/submission`)
+          .set('x-jwt-token', template.formio.owner.token);
+
+        const formSubmissions = formSubmissionsRes.body;
+
+        assert.equal(formSubmissions.length, 1);
+        assert.ok(formSubmissions[0].data.hasOwnProperty(selectComponent.key));
+
+        const firstSubmissionData = _.omit(formSubmissions[0].data[selectComponent.key], ['deleted', 'externalTokens', '__v']);
+
+        assert.deepEqual({ [selectComponent.key]: firstSubmissionData }, { [selectComponent.key]: resourceSubmission });
+      });
+
+      after(done => {
+        // Reset modified env values
+        process.env.TEST_SIMULATE_SAC_PACKAGE = false;
+        process.env.API_KEYS = '';
+
+        // Reset changes made to the project
+        request(app)
+          .put(`/project/${helper.template.project._id}`)
+          .set('x-jwt-token', template.formio.owner.token)
+          .send({
+            plan: 'trial',
+            settings: {}
+          })
+          .expect(200)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            const resetProject = res.body;
+
+            assert.equal(resetProject._id, helper.template.project._id);
+            assert.equal(resetProject.plan, 'trial');
+            assert.deepEqual(resetProject.settings, {});
+
+            helper.template.project = resetProject;
+
+            done();
+          });
+      });
+    });
+
     describe('Unnested Submissions', function() {
       it('Saves values for each single value component type1', function(done) {
         var test = require('./fixtures/forms/singlecomponents1.js');
@@ -3793,7 +4018,7 @@ module.exports = function(app, template, hook) {
               "delimiter": true
             }
           ];
-  
+
           helper
             .form('filterCurrency', components)
             .submission({ currency: 10 })
@@ -3845,7 +4070,7 @@ module.exports = function(app, template, hook) {
               }
             }
           ];
-  
+
           helper
             .form('filterSelectBoxes', components)
             .submission({ selectBoxes: {a: true, b: false} })
@@ -3911,7 +4136,7 @@ module.exports = function(app, template, hook) {
               }
             }
           ];
-  
+
           helper
             .form('filter', components)
             .submission({ currency: 10 , selectBoxes: {a: true, b: false}})


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-4216
https://formio.atlassian.net/browse/FIO-6601

## Description

**What changed?**

Previously, only default 'submissions' db collection was checked when getting all form submissions and value is a reference. With this changes the name for db collection is composed from project name and form settings 'collection' config.

**Why have you chosen this solution?**

This felt the normal way to do this.

## Dependencies

None

## How has this PR been tested?

I added automated tests + manually

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
