### PR TITLE
FIO-6840: Refactor authentication to use case-insensitive query and fallback to $regex

### DIFF
--- a/src/authentication/index.js
+++ b/src/authentication/index.js
@@ -194,6 +194,99 @@ module.exports = (router) => {
     });
   };
 
+  const evaluateUser = (req, user, password, passField, username, next) => {
+    if (!user) {
+      return next('User or password was incorrect');
+    }
+
+    const hash = _.get(user.data, passField);
+    if (!hash) {
+      audit('EAUTH_BLANKPW', {
+        ...req,
+        userId: user._id,
+      }, username);
+      return next('Your account does not have a password. You must reset your password to login.');
+    }
+
+    // Compare the provided password.
+    bcrypt.compare(password, hash, (err, value) => {
+      if (err) {
+        audit('EAUTH_BCRYPT', {
+          ...req,
+          userId: user._id
+        }, username, err);
+        return next(err);
+      }
+
+      if (!value) {
+        audit('EAUTH_PASSWORD', req, user._id, username);
+        return next('User or password was incorrect', {user});
+      }
+
+      // Load the form associated with this user record.
+      router.formio.resources.form.model.findOne({
+        _id: user.form,
+        deleted: {$eq: null},
+      }).lean().exec((err, form) => {
+        if (err) {
+          audit('EAUTH_USERFORM', {
+            ...req,
+            userId: user._id,
+          }, user.form, err);
+          return next(err);
+        }
+
+        if (!form) {
+          audit('EAUTH_USERFORM', {
+            ...req,
+            userId: user._id,
+          }, user.form, {message: 'User form not found'});
+          return next('User form not found.');
+        }
+
+        // Allow anyone to hook and modify the user.
+        hook.alter('user', user, (err, _user) => {
+          if (err) {
+            // Attempt to fail safely and not update the user reference.
+            debug.authenticate(err);
+          }
+          else {
+            // Update the user with the hook results.
+            debug.authenticate(user);
+            user = _user;
+          }
+
+          hook.alter('login', user, req, (err) => {
+            if (err) {
+              return next(err);
+            }
+
+            // Allow anyone to hook and modify the token.
+            const token = hook.alter('token', {
+              user: {
+                _id: user._id,
+              },
+              form: {
+                _id: form._id,
+              },
+            }, form, req);
+
+            hook.alter('tokenDecode', token, req, (err, decoded) => {
+              // Continue with the token data.
+              next(err, {
+                user,
+                token: {
+                  token: getToken(token),
+                  decoded,
+                },
+              });
+            });
+          });
+        });
+      });
+    });
+  };
+
   /**
    * Authenticate a user.
    *
@@ -210,7 +303,7 @@ module.exports = (router) => {
    * @param next {Function}
    *   The callback function to call after authentication.
    */
-  const authenticate = (req, forms, userField, passField, username, password, next) => {
+  const authenticate = async (req, forms, userField, passField, username, password, next) => {
     // Make sure they have provided a username and password.
     if (!username) {
       audit('EAUTH_EMPTYUN', req);
@@ -235,105 +328,31 @@ module.exports = (router) => {
     }
 
     // Look for the user.
-    query[`data.${userField}`] = {$regex: new RegExp(`^${util.escapeRegExp(username)}$`), $options: 'i'};
+    query[`data.${userField}`] = username;
 
     // Find the user object.
     const submissionModel = req.submissionModel || router.formio.resources.submission.model;
-    submissionModel.findOne(hook.alter('submissionQuery', query, req)).lean().exec((err, user) => {
-      if (err) {
-        return next(err);
-      }
-      if (!user) {
-        return next('User or password was incorrect');
-      }
-
-      const hash = _.get(user.data, passField);
-      if (!hash) {
-        audit('EAUTH_BLANKPW', {
-          ...req,
-          userId: user._id,
-        }, username);
-        return next('Your account does not have a password. You must reset your password to login.');
-      }
-
-      // Compare the provided password.
-      bcrypt.compare(password, hash, (err, value) => {
+    submissionModel
+      .findOne(hook.alter('submissionQuery', query, req))
+      .collation({locale: 'en', strength: 2})
+      .lean()
+      .exec((err, user) => {
         if (err) {
-          audit('EAUTH_BCRYPT', {
-            ...req,
-            userId: user._id
-          }, username, err);
-          return next(err);
-        }
-
-        if (!value) {
-          audit('EAUTH_PASSWORD', req, user._id, username);
-          return next('User or password was incorrect', {user});
-        }
-
-        // Load the form associated with this user record.
-        router.formio.resources.form.model.findOne({
-          _id: user.form,
-          deleted: {$eq: null},
-        }).lean().exec((err, form) => {
-          if (err) {
-            audit('EAUTH_USERFORM', {
-              ...req,
-              userId: user._id,
-            }, user.form, err);
-            return next(err);
-          }
-
-          if (!form) {
-            audit('EAUTH_USERFORM', {
-              ...req,
-              userId: user._id,
-            }, user.form, {message: 'User form not found'});
-            return next('User form not found.');
-          }
-
-          // Allow anyone to hook and modify the user.
-          hook.alter('user', user, (err, _user) => {
-            if (err) {
-              // Attempt to fail safely and not update the user reference.
-              debug.authenticate(err);
-            }
-            else {
-              // Update the user with the hook results.
-              debug.authenticate(user);
-              user = _user;
-            }
-
-            hook.alter('login', user, req, (err) => {
+          // Presume that the error comes from our database not supporting case-insensitive collation indexing/querying
+          // (e.g. DocumentDB) and retry as a case-insensitive regex search
+          query[`data.${userField}`] = {$regex: new RegExp(`^${util.escapeRegExp(username)}$`, 'i')};
+          submissionModel
+            .findOne(hook.alter('submissionQuery', query, req)).lean().exec((err, user) => {
               if (err) {
                 return next(err);
               }
-
-              // Allow anyone to hook and modify the token.
-              const token = hook.alter('token', {
-                user: {
-                  _id: user._id,
-                },
-                form: {
-                  _id: form._id,
-                },
-              }, form, req);
-
-              hook.alter('tokenDecode', token, req, (err, decoded) => {
-                // Continue with the token data.
-                next(err, {
-                  user,
-                  token: {
-                    token: getToken(token),
-                    decoded,
-                  },
-                });
-              });
+              return evaluateUser(req, user, password, passField, username, next);
             });
-          });
-        });
+        }
+        else {
+          return evaluateUser(req, user, password, passField, username, next);
+        }
       });
-    });
   };
 
   /**

--- a/src/authentication/index.js
+++ b/src/authentication/index.js
@@ -194,6 +194,22 @@ module.exports = (router) => {
     });
   };
 
+  /**
+   * Evaluate a user after querying the database.
+   *
+   * @param req {Object}
+   *   The express request object
+   * @param user {Object}
+   *   The user submission field that contains the username.
+   * @param password {String}
+   *   The user submission password
+   * @param passField {String}
+   *   The user submission field that contains the password.
+   * @param username {String}
+   *   The user submission username to login with.
+   * @param next {Function}
+   *   The callback function to call after authentication.
+   */
   const evaluateUser = (req, user, password, passField, username, next) => {
     if (!user) {
       return next('User or password was incorrect');

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -3,7 +3,6 @@
 const async = require('async');
 const MongoClient = require('mongodb').MongoClient;
 const semver = require('semver');
-const fetch = require('@formio/node-fetch-http-proxy');
 const _ = require('lodash');
 const fs = require('fs');
 const debug = {

--- a/src/db/updates/3.1.5.js
+++ b/src/db/updates/3.1.5.js
@@ -1,0 +1,43 @@
+const debug = require('debug')('formio:db');
+
+/**
+ * Update 3.1.5
+ *
+ * Add a case insensitive index to the data.email field in the submissions collection
+ *
+ * @param db
+ * @param config
+ * @param tools
+ * @param done
+ */
+module.exports = async function(db, config, tools, done) {
+  let submissionsCollection = db.collection('submissions');
+  // Check if an index already exists on the submissions collection for the data.email field
+  let indexExists = await submissionsCollection.indexExists('form_1_project_1_data.email_1_deleted_1');
+
+  if (indexExists) {
+    debug('`data.email` index exists exists, dropping');
+    await submissionsCollection.dropIndex('form_1_project_1_data.email_1_deleted_1');
+  }
+
+  try {
+    // Create a case-sensitive index on the submissions collection for the data.email field
+    await submissionsCollection.createIndex(
+      { form: 1, project: 1, 'data.email': 1, deleted: 1 },
+      { background: true, collation: { locale: 'en', strength: 2 } }
+    );
+  }
+  catch (err) {
+    // We assume that an error means MongoDB API incompatibility (i.e. MongoDB < 3.4.0 or DocumentDB) so we'll create the index as normal
+    debug('Case insensitive index creation failed, falling back to non-collated index creation');
+    try {
+      await submissionsCollection.createIndex({ form: 1, project: 1, 'data.email': 1, deleted: 1 }, { background: true });
+    }
+    catch (err) {
+      debug(err);
+      debug('Index creation failed with error above, skipping');
+    }
+  }
+
+  done();
+};


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6840

## Description

Long running `$regex` queries were appearing in our hosted production environment, sometimes taking as long as 10-12 seconds even when there is an index. It turns out that [case insensitive `$regex` queries cannot utilize indexes](https://www.mongodb.com/docs/manual/reference/operator/query/regex/#index-use), so this PR 
* adds a case-insensitive index for the `data.email` property; and
* changes the authentication method to attempt to utilize a collation-aware (i.e. case-insensitive) query before falling back to a $regex query.

With this change, OSS formio's authentication process should be a lot more performant.

## Dependencies

*This PR depends on the following PRs from other Form.io modules: ...*

## How has this PR been tested?

Since this PR adds a schema update and a collation-aware index, it is difficult to write an automated test that covers this code as DocumentDB won't allow creation of a collation-aware index. However, the test suite still passes and I tested new and updated environments manually versus both MongoDB and DocumentDB.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
