### PR TITLE
fix submission collections tests failing on hosted env

### DIFF
--- a/test/submission.js
+++ b/test/submission.js
@@ -34,7 +34,7 @@ module.exports = function(app, template, hook) {
       helper.project().user('user', 'user1').execute(done);
     });
 
-    if (app.hasProjects || docker)
+    if ((app.hasProjects || docker) && !_.get(template, 'config.formio.hosted'))
     describe('Submissions Collection', () => {
       const test = require('./fixtures/forms/singlecomponents1.js');
 


### PR DESCRIPTION
I wrote a test in OSS formio that dealt with custom submission collections. Since the test suite runs with a hosted license, I added a check for config.hosted for that particular test 