### PR TITLE
FIO-4216 | FIO-6601 - Fixes no custom submission collection lookup when getting submissions

### DIFF
--- a/src/actions/properties/reference.js
+++ b/src/actions/properties/reference.js
@@ -198,9 +198,16 @@ module.exports = (router) => {
   // Build a pipeline to load all references within an index.
   const buildPipeline = function(component, path, req, res) {
     // First check their access within this form.
-    return checkAccess(component, req.query, req, res).then(() => {
+    return checkAccess(component, req.query, req, res).then(async () => {
       const formId = component.form || component.resource || component.data.resource;
-
+      const form = await new Promise((resolve, reject) =>
+        router.formio.cache.loadForm(req, null, formId, (err, form) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(form);
+        })
+      );
       // Get the subquery.
       const subQuery = getSubQuery(formId, req.query, path);
       const subQueryReq = {query: subQuery.match};
@@ -208,11 +215,17 @@ module.exports = (router) => {
 
       // Create the pipeline for this component.
       let pipeline = [];
-
+      const submissionsCollectionName =
+        form.settings && form.settings.collection
+          ? `${req.currentProject.name.replace(
+              /[^A-Za-z0-9]+/g,
+              ''
+            )}_${form.settings.collection.replace(/[^A-Za-z0-9]+/g, '')}`
+          : 'submissions';
       // Load the reference.
       pipeline.push({
         $lookup: {
-          from: 'submissions',
+          from: submissionsCollectionName,
           localField: `data.${path}._id`,
           foreignField: '_id',
           as: `data.${path}`
@@ -244,24 +257,17 @@ module.exports = (router) => {
       }
 
       return new Promise((resolve, reject) => {
-        // Load the form.
-        router.formio.cache.loadForm(req, null, formId, function(err, form) {
-          if (err) {
-            return reject(err);
+        // Build the pipeline for the subdata.
+        var queues = [];
+        util.FormioUtils.eachComponent(form.components, (subcomp, subpath) => {
+          if (subcomp.reference) {
+            queues.push(buildPipeline(subcomp, `${path}.data.${subpath}`, req, res).then((subpipe) => {
+              pipeline = pipeline.concat(subpipe);
+            }));
           }
-
-          // Build the pipeline for the subdata.
-          var queues = [];
-          util.FormioUtils.eachComponent(form.components, (subcomp, subpath) => {
-            if (subcomp.reference) {
-              queues.push(buildPipeline(subcomp, `${path}.data.${subpath}`, req, res).then((subpipe) => {
-                pipeline = pipeline.concat(subpipe);
-              }));
-            }
-          });
-
-          Promise.all(queues).then(() => resolve(pipeline)).catch((err) => reject(err));
         });
+
+        Promise.all(queues).then(() => resolve(pipeline)).catch((err) => reject(err));
       });
     });
   };

--- a/src/middleware/filterMongooseExists.js
+++ b/src/middleware/filterMongooseExists.js
@@ -33,10 +33,10 @@ module.exports = (router) => (settings) => function(req, res, next) {
     query[settings.field] = exists;
   }
 
-  req.modelQuery = req.modelQuery || req.model || req.submissionModel || this.model;
+  req.modelQuery = router.formio.hook.alter('query', req) || this.model;
   req.modelQuery = req.modelQuery.find(query);
 
-  req.countQuery = req.countQuery || req.model || req.submissionModel || this.model;
+  req.countQuery = router.formio.hook.alter('query', req) || this.model;
   req.countQuery = req.countQuery.find(query);
 
   next();

--- a/src/middleware/filterMongooseExists.js
+++ b/src/middleware/filterMongooseExists.js
@@ -33,10 +33,10 @@ module.exports = (router) => (settings) => function(req, res, next) {
     query[settings.field] = exists;
   }
 
-  req.modelQuery = router.formio.hook.alter('query', req) || this.model;
+  req.modelQuery = req.modelQuery || req.model || this.model;
   req.modelQuery = req.modelQuery.find(query);
 
-  req.countQuery = router.formio.hook.alter('query', req) || this.model;
+  req.countQuery = req.countQuery || req.model || this.model;
   req.countQuery = req.countQuery.find(query);
 
   next();


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-4216
https://formio.atlassian.net/browse/FIO-6601

## Description

**What changed?**

Previously, only default 'submissions' db collection was checked when getting all form submissions and value is a reference. With this changes the name for db collection is composed from project name and form settings 'collection' config.

**Why have you chosen this solution?**

This felt the normal way to do this.

## Dependencies

[formio-server:1294](https://github.com/formio/formio-server/pull/1294)

## How has this PR been tested?

I added automated tests + manually

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
