### PR TITLE
skip form alias for pdf proxy

### DIFF
--- a/src/middleware/alias.js
+++ b/src/middleware/alias.js
@@ -35,6 +35,10 @@ module.exports = function(router) {
 
   // Handle the request.
   return function aliasHandler(req, res, next) {
+    // Skip alias handler for PDF proxy requests
+    if (req.url.includes('pdf-proxy')) {
+      return next();
+    }
     // Allow a base url to be provided to the alias handler.
     const baseUrl = aliasHandler.baseUrl ? aliasHandler.baseUrl(req) : '';
 


### PR DESCRIPTION
## Description

**What changed?**

*Previously, pdf poxy requests were failing with Invalid alias error. Now that middleware is skipped for pdf proxy requests.*

## Dependencies

none

## How has this PR been tested?

manually

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
