### PR TITLE
FIO-6966: Fixes empty address component data in CSV

### DIFF
--- a/src/export/exporters/CSVExporter.js
+++ b/src/export/exporters/CSVExporter.js
@@ -68,7 +68,10 @@ class CSVExporter extends Exporter {
               }
 
               const address = (value && value.address) || value || {};
-              return address.formatted_address || '';
+
+              // OpenStreetMap || Azure || Google
+              // eslint-disable-next-line max-len
+              return address.display_name || _.get(address, 'address.freeformAddress') || address.formatted_address || '';
             },
           });
           items.push({
@@ -79,7 +82,9 @@ class CSVExporter extends Exporter {
               }
 
               const address = (value && value.address) || value || {};
-              return _.get(address, 'geometry.location.lat', '');
+
+              // OpenStreetMap || Azure || Google
+              return address.lat || _.get(address, 'position.lat') || _.get(address, 'geometry.location.lat') || '';
             },
           });
           items.push({
@@ -90,7 +95,9 @@ class CSVExporter extends Exporter {
               }
 
               const address = (value && value.address) || value || {};
-              return _.get(address, 'geometry.location.lng', '');
+
+              // OpenStreetMap || Azure || Google
+              return address.lon || _.get(address, 'position.lon') || _.get(address, 'geometry.location.lng') || '';
             },
           });
 

--- a/test/export/CSVExporter/CSVExporter.js
+++ b/test/export/CSVExporter/CSVExporter.js
@@ -1,5 +1,3 @@
-const testFile = require('../../fixtures/forms/fileComponent.js');
-const assert = require('assert');
 module.exports = function(app, template, hook) {
   const docker = process.env.DOCKER;
   const assert = require('assert');
@@ -9,6 +7,9 @@ module.exports = function(app, template, hook) {
   const testFile = require('../../fixtures/forms/fileComponent.js');
   const testTags = require('../../fixtures/forms/tagsWithDelimiter.js');
   const testRadio = require('../../fixtures/forms/radioComponent');
+  const testAzureAddress= require('../../fixtures/forms/azureAddressComponent');
+  const testGoogleAddress= require('../../fixtures/forms/googleAddressComponent');
+  const testNominatimAddress= require('../../fixtures/forms/nominatimAddressComponent');
 
   function getComponentValue(exportedText, compKey, submissionIndex) {
     const rows = exportedText.split('\n');
@@ -16,7 +17,7 @@ module.exports = function(app, template, hook) {
     const headings = headerRow.split(/,(?=")/);
     const compColIndex = headings.indexOf(`"${compKey}"`);
     const submissionRow = rows[submissionIndex + 1];
-    const submissionRowValues = submissionRow.split(/,(?=")/);;
+    const submissionRowValues = submissionRow.split(/,(?=")/);
     const compValue = submissionRowValues[compColIndex];
     console.log({
       rows,
@@ -160,6 +161,102 @@ module.exports = function(app, template, hook) {
             const fileValue = getComponentValue(result.text, 'radio', 0);
             const expectedValue = '"false"';
             assert.strictEqual(fileValue, expectedValue);
+            done();
+          });
+        });
+    });
+
+    it(`Test Azure address data`, (done) => {
+      let owner = (app.hasProjects || docker) ? template.formio.owner : template.users.admin;
+      helper = new Helper(owner);
+      helper
+        .form('testAzureAddress', testAzureAddress.components)
+        .submission(testAzureAddress.submission)
+        .execute((err) => {
+          if (err) {
+            return done(err);
+          }
+
+          helper.getExport(helper.template.forms.testAzureAddress, 'csv', (error, result) => {
+            if (error) {
+              done(error);
+            }
+
+            const addressLat = getComponentValue(result.text, 'address.lat', 0);
+            const addressLng = getComponentValue(result.text, 'address.lng', 0);
+            const addressName = getComponentValue(result.text, 'address.formatted', 0);
+
+            const expectedAddressLat = '"35.68696"';
+            const expectedAddressLng = '"139.74946"';
+            const expectedAddressName = '"Tokyo, Kanto"';
+
+            assert.strictEqual(addressLat, expectedAddressLat);
+            assert.strictEqual(addressLng, expectedAddressLng);
+            assert.strictEqual(addressName, expectedAddressName);
+            done();
+          });
+        });
+    });
+
+    it(`Test Google address data`, (done) => {
+      let owner = (app.hasProjects || docker) ? template.formio.owner : template.users.admin;
+      helper = new Helper(owner);
+      helper
+        .form('testGoogleAddress', testGoogleAddress.components)
+        .submission(testGoogleAddress.submission)
+        .execute((err) => {
+          if (err) {
+            return done(err);
+          }
+
+          helper.getExport(helper.template.forms.testGoogleAddress, 'csv', (error, result) => {
+            if (error) {
+              done(error);
+            }
+
+            const addressLat = getComponentValue(result.text, 'address.lat', 0);
+            const addressLng = getComponentValue(result.text, 'address.lng', 0);
+            const addressName = getComponentValue(result.text, 'address.formatted', 0);
+
+            const expectedAddressLat = '"35.6761919"';
+            const expectedAddressLng = '"139.6503106"';
+            const expectedAddressName = '"Tokyo, Japan"';
+
+            assert.strictEqual(addressLat, expectedAddressLat);
+            assert.strictEqual(addressLng, expectedAddressLng);
+            assert.strictEqual(addressName, expectedAddressName);
+            done();
+          });
+        });
+    });
+
+    it(`Test OpenStreetMap Nominatim address data`, (done) => {
+      let owner = (app.hasProjects || docker) ? template.formio.owner : template.users.admin;
+      helper = new Helper(owner);
+      helper
+        .form('testNominatimAddress', testNominatimAddress.components)
+        .submission(testNominatimAddress.submission)
+        .execute((err) => {
+          if (err) {
+            return done(err);
+          }
+
+          helper.getExport(helper.template.forms.testNominatimAddress, 'csv', (error, result) => {
+            if (error) {
+              done(error);
+            }
+
+            const addressLat = getComponentValue(result.text, 'address.lat', 0);
+            const addressLng = getComponentValue(result.text, 'address.lng', 0);
+            const addressName = getComponentValue(result.text, 'address.formatted', 0);
+
+            const expectedAddressLat = '"35.6840574"';
+            const expectedAddressLng = '"139.7744912"';
+            const expectedAddressName = '"Tokyo, Japan"';
+
+            assert.strictEqual(addressLat, expectedAddressLat);
+            assert.strictEqual(addressLng, expectedAddressLng);
+            assert.strictEqual(addressName, expectedAddressName);
             done();
           });
         });

--- a/test/fixtures/forms/azureAddressComponent.js
+++ b/test/fixtures/forms/azureAddressComponent.js
@@ -1,0 +1,98 @@
+module.exports = {
+  components: [
+    {
+      label: "Address",
+      enableManualMode: true,
+      tableView: true,
+      defaultValue: {},
+      allowCalculateOverride: true,
+      provider: "azure",
+      validate: {
+        json: "\"\""
+      },
+      errors: "\"\"",
+      key: "address",
+      conditional: {
+        "json": "\"\""
+      },
+      type: "address",
+      providerOptions: {
+        params: {
+          "subscription-key": "AZURE_API_KEY"
+        }
+      },
+      input: true,
+    },
+    {
+      type: "button",
+      label: "Submit",
+      key: "submit",
+      disableOnInvalid: true,
+      input: true,
+      tableView: false,
+    },
+  ],
+  submission: {
+    "data": {
+      "textField": "Test Address",
+      "address": {
+        "mode": "autocomplete",
+        "address":{
+          "type": "Geography",
+          "id": "TbOmYMFBz7Hm8q_lxc-oCA",
+          "score": 2.3817019463,
+          "entityType": "Municipality",
+          "matchConfidence": {
+            "score": 1
+          },
+          "address": {
+            "municipality": "Tokyo",
+            "countrySubdivision": "Kanto",
+            "countryCode": "JP",
+            "country": "Japan",
+            "countryCodeISO3": "JPN",
+            "freeformAddress": "Tokyo, Kanto"
+          },
+          "position": {
+            "lat": 35.68696,
+            "lon": 139.74946
+          },
+          "viewport": {
+            "topLeftPoint": {
+              "lat": 37.14388,
+              "lon": 138.37411
+            },
+            "btmRightPoint": {
+              "lat": 34.89988,
+              "lon": 140.87509
+            }
+          },
+          "boundingBox": {
+            "topLeftPoint": {
+              "lat": 37.14388,
+              "lon": 138.37411
+            },
+            "btmRightPoint": {
+              "lat": 34.89988,
+              "lon": 140.87509
+            }
+          },
+          "dataSources": {
+            "geometry": {
+              "id": "00005858-5800-1200-0000-00007d30cf7f"
+            }
+          },
+          "address1": "",
+          "address2": "",
+          "city": "",
+          "state": "",
+          "country": "",
+          "zip": ""
+        }
+      },
+      "submit": true
+    },
+    "state": "submitted",
+    "_vnote": ""
+  }
+};

--- a/test/fixtures/forms/googleAddressComponent.js
+++ b/test/fixtures/forms/googleAddressComponent.js
@@ -1,0 +1,92 @@
+module.exports = {
+  components: [
+    {
+      label: "Address",
+      enableManualMode: true,
+      tableView: true,
+      defaultValue: {},
+      allowCalculateOverride: true,
+      provider: "google",
+      validate: {
+        json: "\"\""
+      },
+      errors: "\"\"",
+      key: "address",
+      conditional: {
+        "json": "\"\""
+      },
+      type: "address",
+      providerOptions: {
+        params: {
+          key: "GOOGLE_MAPS_API_KEY",
+          autocompleteOptions: {}
+        }
+      },
+      input: true,
+    },
+    {
+      type: "button",
+      label: "Submit",
+      key: "submit",
+      disableOnInvalid: true,
+      input: true,
+      tableView: false,
+    },
+  ],
+  submission: {
+    "data": {
+      "textField": "Test",
+      "address": {
+        "mode": "autocomplete",
+        "address": {
+          "address_components": [
+            {
+              "long_name": "Tokyo",
+              "short_name": "Tokyo",
+              "types": [
+                "administrative_area_level_1",
+                "political"
+              ]
+            },
+            {
+              "long_name": "Japan",
+              "short_name": "JP",
+              "types": [
+                "country",
+                "political"
+              ]
+            }
+          ],
+          "formatted_address": "Tokyo, Japan",
+          "geometry": {
+            "location": {
+              "lat": 35.6761919,
+              "lng": 139.6503106
+            },
+            "viewport": {
+              "south": 34.5776326,
+              "west": 138.2991098,
+              "north": 36.4408483,
+              "east": 141.2405144
+            }
+          },
+          "place_id": "ChIJ51cu8IcbXWARiRtXIothAS4",
+          "types": [
+            "administrative_area_level_1",
+            "political"
+          ],
+          "formattedPlace": "Tokyo, Japan",
+          "address1": "",
+          "address2": "",
+          "city": "",
+          "state": "",
+          "country": "",
+          "zip": ""
+        }
+      },
+      "submit": true
+    },
+    "state": "submitted",
+    "_vnote": ""
+  }
+};

--- a/test/fixtures/forms/nominatimAddressComponent.js
+++ b/test/fixtures/forms/nominatimAddressComponent.js
@@ -1,0 +1,75 @@
+module.exports = {
+  components: [
+    {
+      label: "Address",
+      enableManualMode: true,
+      tableView: true,
+      defaultValue: {},
+      allowCalculateOverride: true,
+      provider: "nominatim",
+      validate: {
+        json: "\"\""
+      },
+      errors: "\"\"",
+      key: "address",
+      conditional: {
+        "json": "\"\""
+      },
+      type: "address",
+      providerOptions: {
+        params: {}
+      },
+      input: true,
+    },
+    {
+      type: "button",
+      label: "Submit",
+      key: "submit",
+      disableOnInvalid: true,
+      input: true,
+      tableView: false,
+    },
+  ],
+  submission: {
+    "data": {
+      "textField": "Test",
+      "address": {
+        "mode": "autocomplete",
+        "address": {
+          "place_id": 308320215,
+          "licence": "Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright",
+          "osm_type": "relation",
+          "osm_id": 1543125,
+          "boundingbox": [
+            "20.2145811",
+            "35.8984245",
+            "135.8536855",
+            "154.205541"
+          ],
+          "lat": "35.6840574",
+          "lon": "139.7744912",
+          "display_name": "Tokyo, Japan",
+          "class": "boundary",
+          "type": "administrative",
+          "importance": 0.8693311914925306,
+          "icon": "https://nominatim.openstreetmap.org/ui/mapicons/poi_boundary_administrative.p.20.png",
+          "address": {
+            "city": "Tokyo",
+            "ISO3166-2-lvl4": "JP-13",
+            "country": "Japan",
+            "country_code": "jp"
+          },
+          "address1": "",
+          "address2": "",
+          "city": "",
+          "state": "",
+          "country": "",
+          "zip": ""
+        }
+      },
+      "submit": true
+    },
+    "state": "submitted",
+    "_vnote": ""
+  }
+};


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6966

## Description

**What changed?**

Previously, address component data mapping was outdated and address component data in CSV appeared empty.

**Why have you chosen this solution?**

This seemed to be the right spot to fix address component data mapping for CSV submissions export.

## Dependencies

None

## How has this PR been tested?

I've added automated tests to cover OpenStreetMap, Azure Maps and Google Maps cases

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
