### PR TITLE
Re-implement - FIO-6630: Expanded Actions Logic UI

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -11,6 +11,14 @@ const debug = {
 const util = require('../util/util');
 const moment = require('moment');
 const promisify = require('util').promisify;
+const {
+  ConditionOperators,
+  filterComponentsForConditionComponentFieldOptions,
+  conditionOperatorsByComponentType,
+  allConditionOperatorsOptions,
+  getValueComponentsForEachFormComponent,
+  getValueComponentRequiredSettings,
+} = require('../util/conditionOperators');
 
 /**
  * The ActionIndex export.
@@ -281,18 +289,13 @@ module.exports = (router) => {
           return false;
         }
       }
-      else {
-        if (_.isEmpty(condition.field) || _.isEmpty(condition.eq)) {
-          return true;
-        }
 
+      // Check if the action has a condition saved using the old format
+      if (!_.isEmpty(condition.field) && !_.isEmpty(condition.eq)) {
         // See if a condition is not established within the action.
         const field = condition.field || '';
         const eq = condition.eq || '';
-        const isDelete = req.method.toUpperCase() === 'DELETE';
-        const deletedSubmission = isDelete ? await getDeletedSubmission(req): false;
-        const value = isDelete? String(_.get(deletedSubmission, `data.${field}`, '')) :
-          String(_.get(req, `body.data.${field}`, ''));
+        const value = String(await getComponentValueFromRequest(req, field));
         const compare = String(condition.value || '');
         debug.action(
           '\nfield', field,
@@ -305,6 +308,31 @@ module.exports = (router) => {
         return (eq === 'equals') ===
           ((Array.isArray(value) && value.map(String).includes(compare)) || (value === compare));
       }
+      else if (_.some(condition.conditions || [], condition => condition.component && condition.operator)) {
+        const {conditions = [], conjunction = 'all'} = condition;
+
+        // Check all the conditions and save results to array
+        const conditionsResults = await Promise.all(conditions.map(async (cond) => {
+          const {value: comparedValue, operator, component: conditionComponentPath} = cond;
+          const ConditionOperator = ConditionOperators[operator];
+          if (!conditionComponentPath || !ConditionOperator) {
+            return true;
+          }
+          const value = await getComponentValueFromRequest(req, conditionComponentPath);
+          let component;
+          if (req.currentFormComponents) {
+            component = util.FormioUtils.getComponent(req.currentFormComponents, conditionComponentPath);
+          }
+          return new ConditionOperator().getResult({value, comparedValue, component});
+        }));
+
+        return conjunction === 'any' ?
+            _.some(conditionsResults, res => !!res) :
+            _.every(conditionsResults, res => !!res);
+      }
+
+      // If there are no conditions either in the old nor in the new format, allow executing an action
+      return true;
     },
   };
 
@@ -401,14 +429,21 @@ module.exports = (router) => {
         return cb('Could not load form components for conditional actions.');
       }
 
-      const filteredComponents = _.filter(router.formio.util.flattenComponents(form.components),
-        (component) => component.key && component.input === true);
+      const flattenedComponents = router.formio.util.flattenComponents(form.components);
 
-      const components = [{key: ''}].concat(filteredComponents);
-      const customPlaceholder =
-`// Example: Only execute if submitted roles has 'authenticated'.
-JavaScript: execute = (data.roles.indexOf('authenticated') !== -1);
-JSON: { "in": [ "authenticated", { "var": "data.roles" } ] }`;
+      const componentsOptionsForExtendedUi = filterComponentsForConditionComponentFieldOptions(flattenedComponents);
+      const flattenedComponentsForConditional = _.pick(
+          flattenedComponents,
+          componentsOptionsForExtendedUi.map(({value}) => value)
+      );
+      const valueComponentsByComponentPath = getValueComponentsForEachFormComponent(flattenedComponentsForConditional);
+      const valueComponent = getValueComponentRequiredSettings(valueComponentsByComponentPath);
+
+      const customPlaceholder = `
+        // Example: Only execute if submitted roles has 'authenticated'.
+        JavaScript: execute = (data.roles.indexOf('authenticated') !== -1);
+        JSON: { "in": [ "authenticated", { "var": "data.roles" } ] }
+      `;
       conditionalSettings.components.push({
         type: 'container',
         key: 'condition',
@@ -423,56 +458,87 @@ JSON: { "in": [ "authenticated", { "var": "data.roles" } ] }`;
               {
                 components: [
                   {
+                    label: 'When',
+                    widget: 'choicesjs',
+                    tableView: true,
+                    data: {
+                      values: [
+                        {
+                          label: 'When all conditions are met',
+                          value: 'all',
+                        },
+                        {
+                          label: 'When any condition is met',
+                          value: 'any',
+                        },
+                      ],
+                    },
+                    key: 'conjunction',
                     type: 'select',
                     input: true,
-                    label: 'Trigger this action only if field',
-                    key: 'field',
-                    placeholder: 'Select the conditional field',
-                    template: '<span>{{ item.label || item.key }}</span>',
-                    dataSrc: 'json',
-                    data: {json: JSON.stringify(components)},
-                    valueProperty: 'key',
-                    multiple: false
                   },
                   {
-                    type : 'select',
-                    input : true,
-                    label : '',
-                    key : 'eq',
-                    placeholder : 'Select comparison',
-                    template : '<span>{{ item.label }}</span>',
-                    dataSrc : 'values',
-                    data : {
-                      values : [
-                        {
-                          value : '',
-                          label : ''
-                        },
-                        {
-                          value : 'equals',
-                          label : 'Equals'
-                        },
-                        {
-                          value : 'notEqual',
-                          label : 'Does Not Equal'
-                        }
-                      ],
-                      json : '',
-                      url : '',
-                      resource : ''
+                    label: 'Conditions',
+                    addAnotherPosition: 'bottom',
+                    key: 'conditions',
+                    type: 'editgrid',
+                    initEmpty: true,
+                    addAnother: 'Add Condition',
+                    templates: {
+                      header:`<div class="row">\n      {% util.eachComponent(components, function(component) { %}\n        {% if (displayValue(component)) { %}\n          <div class="col-sm-{{_.includes(['component'], component.key) ? '4' : '3'}}">{{ t(component.label) }}</div>\n        {% } %}\n      {% }) %}\n    </div>`,
+                      row: `<div class="row">\n      {% util.eachComponent(components, function(component) { %}\n        {% if (displayValue(component)) { %}\n          <div class="formio-builder-condition-text col-sm-{{_.includes(['component'], component.key) ? '4' : '3'}}">\n            {{ isVisibleInRow(component) ? getView(component, row[component.key]) : ''}}\n          </div>\n        {% } %}\n      {% }) %}\n      {% if (!instance.options.readOnly && !instance.disabled) { %}\n        <div class="col-sm-2">\n          <div class="btn-group pull-right">\n            <button class="btn btn-default btn-light btn-sm editRow"><i class="{{ iconClass('edit') }}"></i></button>\n            {% if (!instance.hasRemoveButtons || instance.hasRemoveButtons()) { %}\n              <button class="btn btn-danger btn-sm removeRow"><i class="{{ iconClass('trash') }}"></i></button>\n            {% } %}\n          </div>\n        </div>\n      {% } %}\n    </div>`,
                     },
-                    valueProperty : 'value',
-                    multiple : false
-                  },
-                  {
                     input: true,
-                    type: 'textfield',
-                    inputType: 'text',
-                    label: '',
-                    key: 'value',
-                    placeholder: 'Enter value',
-                    multiple: false
-                  }
+                    components: [
+                      {
+                        label: 'When:',
+                        widget: 'choicesjs',
+                        tableView: true,
+                        dataSrc: 'json',
+                        valueProperty: 'value',
+                        placeholder: 'Select Form Component',
+                        lazyLoad: false,
+                        data: {json: JSON.stringify(componentsOptionsForExtendedUi)},
+                        key: 'component',
+                        type: 'select',
+                        input: true,
+                      },
+                      {
+                        label: 'Is:',
+                        widget: 'choicesjs',
+                        tableView: true,
+                        dataSrc: 'custom',
+                        lazyLoad: false,
+                        placeholder: 'Select Comparison Operator',
+                        refreshOn: 'condition.conditions.component',
+                        clearOnRefresh: true,
+                        valueProperty: 'value',
+                        data: {
+                          custom:`
+                            const formComponents = ${JSON.stringify(flattenedComponents)};
+                            const conditionComponent = formComponents[row.component];
+                            const componentType = conditionComponent ? conditionComponent.type : 'base';
+                            const operatorsByComponentType = ${JSON.stringify(conditionOperatorsByComponentType)};
+                            let operators = operatorsByComponentType[componentType];
+                            if (!operators || !operators.length) {
+                              operators = operatorsByComponentType.base;
+                            }
+                            const allOperators = ${JSON.stringify(allConditionOperatorsOptions)};
+
+                            values = allOperators.filter((operator) => operators.includes(operator.value));
+                          `
+                        },
+                        key: 'operator',
+                        type: 'select',
+                        input: true,
+                      },
+                      {
+                        type: 'textfield',
+                        inputFormat: 'plain',
+                        ...valueComponent,
+                      },
+                    ],
+                  },
                 ]
               },
               {
@@ -593,6 +659,14 @@ JSON: { "in": [ "authenticated", { "var": "data.roles" } ] }`;
       debug.error(err);
       return false;
     }
+  }
+
+  async function getComponentValueFromRequest(req, field) {
+    const isDelete = req.method.toUpperCase() === 'DELETE';
+    const deletedSubmission = isDelete ? await getDeletedSubmission(req): false;
+    const value = isDelete? _.get(deletedSubmission, `data.${field}`, '') :
+      _.get(req, `body.data.${field}`, '');
+    return value;
   }
 
   // Return a list of available actions.
@@ -773,6 +847,24 @@ JSON: { "in": [ "authenticated", { "var": "data.roles" } ] }`;
   // Add specific middleware to individual endpoints.
   handlers['beforeDelete'] = handlers['beforeDelete'].concat([router.formio.middleware.deleteActionHandler]);
   handlers['afterIndex'] = handlers['afterIndex'].concat([indexPayload]);
+  handlers['afterGet'] = handlers['afterGet'].concat([
+    (req, res, next) => {
+      if (req.params && req.params.actionId && res.resource && res.resource.item) {
+        const action = res.resource.item;
+        if (action.condition && !_.isEmpty(action.condition.field) && !_.isEmpty(action.condition.eq)) {
+          action.condition = {
+            conjunction: 'all',
+            conditions: [{
+              component: action.condition.field,
+              operator: action.condition.eq === 'equals' ? 'isEqual' : 'isNotEqual',
+              value: action.condition.value,
+            }]
+          };
+        }
+      }
+      return next();
+    }
+  ]);
 
   /**
    * Create the REST properties using ResourceJS, as a nested resource of forms.

--- a/src/util/conditionOperators/ConditionOperator.js
+++ b/src/util/conditionOperators/ConditionOperator.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const _ = require('lodash');
+
+/* eslint-disable no-unused-vars */
+module.exports = class ConditionOperator {
+  static get operatorKey() {
+    return '';
+  }
+
+  static get displayedName() {
+    return '';
+  }
+
+  static get requireValue() {
+    return true;
+  }
+
+  execute() {
+    return true;
+  }
+
+  getResult(options = {}) {
+    const {value} = options;
+
+    if (_.isArray(value)) {
+      return _.some(
+        value,
+        valueItem => this.execute({
+          ...options,
+          value: valueItem,
+        }),
+      );
+    }
+
+    return this.execute(options);
+  }
+};

--- a/src/util/conditionOperators/DateGreaterThan.js
+++ b/src/util/conditionOperators/DateGreaterThan.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const ConditionOperator = require('./ConditionOperator');
+const moment = require('moment');
+
+module.exports = class DateGeaterThan extends ConditionOperator {
+  static get operatorKey() {
+    return 'dateGreaterThan';
+  }
+
+  static get displayedName() {
+    return 'Greater Than';
+  }
+
+  getValidationFormat(component) {
+    return component.dayFirst ? 'DD-MM-YYYY' : 'MM-DD-YYYY';
+  }
+
+  getFormattedDates({
+    value,
+    comparedValue,
+  }) {
+    const date = moment(value);
+    const comparedDate = moment(comparedValue);
+
+    return {
+      date,
+      comparedDate,
+    };
+  }
+
+  execute(options, functionName = 'isAfter') {
+    const {
+      value,
+    } = options;
+
+    if (!value) {
+      return false;
+    }
+
+    const {
+      date,
+      comparedDate,
+    } = this.getFormattedDates(options);
+
+    if (typeof date[functionName] === 'function') {
+      return date[functionName](comparedDate);
+    }
+
+    return false;
+  }
+};

--- a/src/util/conditionOperators/DateGreaterThanOrEqual.js
+++ b/src/util/conditionOperators/DateGreaterThanOrEqual.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const DateGeaterThan = require('./DateGreaterThan');
+
+module.exports = class DateGreaterThanOrEqual extends DateGeaterThan {
+  static get operatorKey() {
+    return 'dateGreaterThanOrEqual';
+  }
+
+  static get displayedName() {
+    return 'Greater Than Or Equal To';
+  }
+
+  execute(options) {
+    return super.execute(options,'isSameOrAfter');
+  }
+};

--- a/src/util/conditionOperators/DateLessThan.js
+++ b/src/util/conditionOperators/DateLessThan.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const DateGeaterThan = require('./DateGreaterThan');
+
+module.exports = class DateLessThan extends DateGeaterThan {
+  static get operatorKey() {
+    return 'dateLessThan';
+  }
+
+  static get displayedName() {
+    return 'Less Than';
+  }
+
+  execute(options) {
+    return super.execute(options,'isBefore');
+  }
+};

--- a/src/util/conditionOperators/DateLessThanOrEqual.js
+++ b/src/util/conditionOperators/DateLessThanOrEqual.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const DateGeaterThan = require('./DateGreaterThan');
+
+module.exports = class DateLessThanOrEqual extends DateGeaterThan {
+  static get operatorKey() {
+    return 'dateLessThanOrEqual';
+  }
+
+  static get displayedName() {
+    return 'Less Than Or Equal To';
+  }
+
+  execute(options) {
+    return super.execute(options,'isSameOrBefore');
+  }
+};

--- a/src/util/conditionOperators/EndsWith.js
+++ b/src/util/conditionOperators/EndsWith.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const ConditionOperator = require('./ConditionOperator');
+const _ = require('lodash');
+
+module.exports = class EndsWith extends ConditionOperator {
+  static get operatorKey() {
+    return 'endsWith';
+  }
+
+  static get displayedName() {
+    return 'Ends With';
+  }
+
+  execute({
+    value,
+    comparedValue,
+  }) {
+    return _.endsWith(value,comparedValue);
+  }
+};

--- a/src/util/conditionOperators/GreaterThan.js
+++ b/src/util/conditionOperators/GreaterThan.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const ConditionOperator = require('./ConditionOperator');
+const _ = require('lodash');
+
+module.exports = class GeaterThan extends ConditionOperator {
+  static get operatorKey() {
+    return 'greaterThan';
+  }
+
+  static get displayedName() {
+    return 'Greater Than';
+  }
+
+  execute({
+    value,
+    comparedValue,
+  }) {
+    return _.isNumber(value) && value > comparedValue;
+  }
+};

--- a/src/util/conditionOperators/GreaterThanOrEqual.js
+++ b/src/util/conditionOperators/GreaterThanOrEqual.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const ConditionOperator = require('./ConditionOperator');
+const _ = require('lodash');
+
+module.exports = class GreaterThanOrEqual extends ConditionOperator {
+  static get operatorKey() {
+    return 'greaterThanOrEqual';
+  }
+
+  static get displayedName() {
+    return 'Greater Than Or Equal To';
+  }
+
+  execute({
+    value,
+    comparedValue,
+  }) {
+    return _.isNumber(value) && (value > comparedValue || _.isEqual(value,comparedValue));
+  }
+};

--- a/src/util/conditionOperators/Includes.js
+++ b/src/util/conditionOperators/Includes.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const ConditionOperator = require('./ConditionOperator');
+const _ = require('lodash');
+
+module.exports = class Includes extends ConditionOperator {
+  static get operatorKey() {
+    return 'includes';
+  }
+
+  static get displayedName() {
+    return 'Includes';
+  }
+
+  execute({
+    value,
+    comparedValue,
+  }) {
+    return _.includes(value,comparedValue);
+  }
+};

--- a/src/util/conditionOperators/IsDateEqual.js
+++ b/src/util/conditionOperators/IsDateEqual.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const DateGeaterThan = require('./DateGreaterThan');
+
+module.exports = class IsDateEqual extends DateGeaterThan {
+  static get operatorKey() {
+    return 'isDateEqual';
+  }
+
+  static get displayedName() {
+    return 'Is Equal To';
+  }
+
+  execute(options) {
+    return super.execute(options,'isSame');
+  }
+};

--- a/src/util/conditionOperators/IsEmptyValue.js
+++ b/src/util/conditionOperators/IsEmptyValue.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const ConditionOperator = require('./ConditionOperator');
+const _ = require('lodash');
+
+module.exports = class IsEmptyValue extends ConditionOperator {
+  static get operatorKey() {
+    return 'isEmpty';
+  }
+
+  static get displayedName() {
+    return 'Is Empty';
+  }
+
+  static get requireValue() {
+    return false;
+  }
+
+  execute({
+    value,
+    instance,
+    component,
+  }) {
+    const isSimpleEmptyValue = (v) => v === null || v === undefined || v === '';
+    // lodash treats Date as an empty object
+    const isEmptyObject = _.isObject(value) && _.isEmpty(value) && !(value instanceof Date);
+    const isEmptyString = typeof value === 'string' && value.trim() === '';
+    const isEmptyArray = _.isArray(value) && value.length === 1 && isSimpleEmptyValue(value[0]);
+    const isEmptyDate = value instanceof Date && value.toString() === 'Invalid Date';
+
+    if (isSimpleEmptyValue(value) ||
+      isEmptyObject ||
+      isEmptyString ||
+      isEmptyArray ||
+      isEmptyDate
+    ) {
+      return true;
+    }
+    else if (component && component.type === 'selectboxes') {
+      let empty = true;
+      for (const key in value) {
+        if (value.hasOwnProperty(key) && value[key]) {
+          empty = false;
+          break;
+        }
+      }
+      return empty;
+    }
+
+    return false;
+  }
+
+  getResult(options) {
+    return this.execute(options);
+  }
+};

--- a/src/util/conditionOperators/IsEqualTo.js
+++ b/src/util/conditionOperators/IsEqualTo.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const ConditionOperator = require('./ConditionOperator');
+const _ = require('lodash');
+
+module.exports = class IsEqualTo extends ConditionOperator {
+  static get operatorKey() {
+    return 'isEqual';
+  }
+
+  static get displayedName() {
+    return 'Is Equal To';
+  }
+
+  execute({
+    value,
+    comparedValue,
+  }) {
+    if (value && comparedValue && typeof value !== typeof comparedValue && _.isString(comparedValue)) {
+      try {
+        comparedValue = JSON.parse(comparedValue);
+      }
+          // eslint-disable-next-line no-empty
+      catch (e) {}
+    }
+
+    //special check for select boxes
+    if (_.isObject(value) && comparedValue && _.isString(comparedValue)) {
+      return value[comparedValue];
+    }
+
+    return _.isEqual(value, comparedValue);
+  }
+};

--- a/src/util/conditionOperators/IsNotDateEqual.js
+++ b/src/util/conditionOperators/IsNotDateEqual.js
@@ -1,0 +1,16 @@
+'use strict';
+const DateGeaterThan = require('./DateGreaterThan');
+
+module.exports = class IsNotDateEqual extends DateGeaterThan {
+  static get operatorKey() {
+    return 'isNotDateEqual';
+  }
+
+  static get displayedName() {
+    return 'Is Not Equal To';
+  }
+
+  execute(options) {
+    return !super.execute(options,'isSame');
+  }
+};

--- a/src/util/conditionOperators/IsNotEmptyValue.js
+++ b/src/util/conditionOperators/IsNotEmptyValue.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const IsEmptyValue = require('./IsEmptyValue');
+
+module.exports = class IsNotEmptyValue extends IsEmptyValue {
+  static get operatorKey() {
+    return 'isNotEmpty';
+  }
+
+  static get displayedName() {
+    return 'Is Not Empty';
+  }
+
+  getResult(options) {
+    return !super.getResult(options);
+  }
+};

--- a/src/util/conditionOperators/IsNotEqualTo.js
+++ b/src/util/conditionOperators/IsNotEqualTo.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const ConditionOperator = require('./ConditionOperator');
+const _ = require('lodash');
+
+module.exports = class IsNotEqualTo extends ConditionOperator {
+  static get operatorKey() {
+    return 'isNotEqual';
+  }
+
+  static get displayedName() {
+    return 'Is Not Equal To';
+  }
+
+  execute({
+    value,
+    comparedValue,
+  }) {
+    return !_.isEqual(value,comparedValue);
+  }
+};

--- a/src/util/conditionOperators/LessThan.js
+++ b/src/util/conditionOperators/LessThan.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const ConditionOperator = require('./ConditionOperator');
+const _ = require('lodash');
+
+module.exports = class LessThan extends ConditionOperator {
+  static get operatorKey() {
+    return 'lessThan';
+  }
+
+  static get displayedName() {
+    return 'Less Than';
+  }
+
+  execute({
+    value,
+    comparedValue,
+  }) {
+    return _.isNumber(value) && value < comparedValue;
+  }
+};

--- a/src/util/conditionOperators/LessThanOrEqual.js
+++ b/src/util/conditionOperators/LessThanOrEqual.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const ConditionOperator = require('./ConditionOperator');
+const _ = require('lodash');
+
+module.exports = class LessThanOrEqual extends ConditionOperator {
+  static get operatorKey() {
+    return 'lessThanOrEqual';
+  }
+
+  static get displayedName() {
+    return 'Less Than Or Equal To';
+  }
+
+  execute({
+    value,
+    comparedValue,
+  }) {
+    return _.isNumber(value) && (value < comparedValue || _.isEqual(value,comparedValue));
+  }
+};

--- a/src/util/conditionOperators/NotIncludes.js
+++ b/src/util/conditionOperators/NotIncludes.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const Includes = require('./Includes');
+
+module.exports = class NotIncludes extends Includes {
+  static get operatorKey() {
+    return 'notIncludes';
+  }
+
+  static get displayedName() {
+    return 'Not Includes';
+  }
+
+  execute(options) {
+    return !super.execute(options);
+  }
+};

--- a/src/util/conditionOperators/StartsWith.js
+++ b/src/util/conditionOperators/StartsWith.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const ConditionOperator = require('./ConditionOperator');
+const _ = require('lodash');
+
+module.exports = class StartsWith extends ConditionOperator {
+  static get operatorKey() {
+    return 'startsWith';
+  }
+
+  static get displayedName() {
+    return 'Starts With';
+  }
+
+  execute({
+    value,
+    comparedValue,
+  }) {
+    return _.startsWith(value, comparedValue);
+  }
+};

--- a/src/util/conditionOperators/index.js
+++ b/src/util/conditionOperators/index.js
@@ -1,0 +1,221 @@
+'use strict';
+
+const IsNotEqualTo = require('./IsNotEqualTo');
+const IsEmptyValue = require('./IsEmptyValue');
+const IsNotEmptyValue = require('./IsNotEmptyValue');
+const LessThan = require('./LessThan');
+const GreaterThan = require('./GreaterThan');
+const IsEqualTo = require('./IsEqualTo');
+const DateGreaterThan = require('./DateGreaterThan');
+const DateLessThan = require('./DateLessThan');
+const Includes = require('./Includes');
+const StartsWith = require('./StartsWith');
+const NotIncludes = require('./NotIncludes');
+const EndsWith = require('./EndsWith');
+const DateGreaterThanOrEqual = require('./DateGreaterThanOrEqual');
+const DateLessThanOrEqual = require('./DateLessThanOrEqual');
+const LessThanOrEqual = require('./LessThanOrEqual');
+const GreaterThanOrEqual = require('./GreaterThanOrEqual');
+const IsDateEqual = require('./IsDateEqual');
+const IsNotDateEqual = require('./IsNotDateEqual');
+const _ = require('lodash');
+const {Formio} = require('../util');
+
+const ConditionOperators = {
+  [`${IsNotEqualTo.operatorKey}`]: IsNotEqualTo,
+  [`${IsEqualTo.operatorKey}`]: IsEqualTo,
+  [`${IsEmptyValue.operatorKey}`]: IsEmptyValue,
+  [`${IsNotEmptyValue.operatorKey}`]: IsNotEmptyValue,
+  [`${LessThan.operatorKey}`]: LessThan,
+  [`${GreaterThan.operatorKey}`]: GreaterThan,
+  [`${DateGreaterThan.operatorKey}`]: DateGreaterThan,
+  [`${DateLessThan.operatorKey}`]: DateLessThan,
+  [`${Includes.operatorKey}`]: Includes,
+  [`${StartsWith.operatorKey}`]: StartsWith,
+  [`${EndsWith.operatorKey}`]: EndsWith,
+  [`${NotIncludes.operatorKey}`]: NotIncludes,
+  [`${DateGreaterThanOrEqual.operatorKey}`]: DateGreaterThanOrEqual,
+  [`${DateLessThanOrEqual.operatorKey}`]: DateLessThanOrEqual,
+  [`${LessThanOrEqual.operatorKey}`]: LessThanOrEqual,
+  [`${GreaterThanOrEqual.operatorKey}`]: GreaterThanOrEqual,
+  [`${IsDateEqual.operatorKey}`]: IsDateEqual,
+  [`${IsNotDateEqual.operatorKey}`]: IsNotDateEqual,
+};
+
+const conditionOperatorsByComponentType = {
+  base: [
+    IsEqualTo.operatorKey,
+    IsNotEqualTo.operatorKey,
+    IsEmptyValue.operatorKey,
+    IsNotEmptyValue.operatorKey,
+  ]};
+
+Object.keys(Formio.Components.components).forEach((type) => {
+  const component = Formio.Components.components[type];
+  const operators = component && component.serverConditionSettings ? component.serverConditionSettings.operators : null;
+  if (operators) {
+    conditionOperatorsByComponentType[type] = operators;
+  }
+});
+
+const filterComponentsForConditionComponentFieldOptions = (flattenedComponents) => _.map(
+    flattenedComponents,
+    (component,path) => ({
+      ...component,
+      path,
+    }),
+)
+    // Hide components without key, layout components, data components and form, datasource, button components
+    .filter((component) => {
+      let allowed = component.key &&
+          component.input === true &&
+          !component.hasOwnProperty('components') &&
+          ![
+            'form',
+            'datasource',
+            'button',
+          ].includes(component.type);
+
+      const pathArr = component.path.split('.');
+
+      // Do not show component if it is inside dataGrid, editGrid, dataMap or tagpad
+      if (pathArr.length > 1) {
+        let subPath = pathArr[0];
+        for (let i = 1; i < pathArr.length; i++) {
+          const parent = flattenedComponents[subPath];
+          if (parent && ['datagrid','editgrid','tagpad','datamap'].includes(parent.type)) {
+            allowed = false;
+            break;
+          }
+          else {
+            subPath += `.${pathArr[i]}`;
+          }
+        }
+      }
+      return allowed;
+    })
+    .map(({
+      path,
+      key,
+      label,
+    }) => ({
+      value: path,
+      label: `${label || key} (${path})`,
+    }));
+
+const allConditionOperatorsOptions = Object.keys(ConditionOperators).map((operatorKey) => ({
+  value: operatorKey,
+  label: ConditionOperators[operatorKey].displayedName,
+}));
+
+const operatorsWithNoValue = _.chain(ConditionOperators)
+  .map(operator => {
+    return !operator.requireValue
+      ? operator.operatorKey
+      : null;
+})
+  .filter(operatorKey => !!operatorKey)
+  .value();
+
+const getValueComponentsForEachFormComponent = (flattenedComponents) => {
+  const valueComponentSettingsByComponentPath = {};
+
+  Object.keys(flattenedComponents).forEach((path) => {
+    const componentSchema = flattenedComponents[path];
+    const component = componentSchema && componentSchema.type
+      ? Formio.Components.components[componentSchema.type]
+      : null;
+    const getValueComponent = component && component.serverConditionSettings ?
+      component.serverConditionSettings.valueComponent :
+      null;
+
+    const valueComponent = getValueComponent && typeof getValueComponent === 'function' ?
+      getValueComponent(componentSchema) :
+      {type: 'textfield'};
+
+    valueComponentSettingsByComponentPath[path] = _.omit(valueComponent, [
+      'logic',
+      'prefix',
+      'suffix',
+      'action',
+      'defaultValue',
+      'conditional',
+      'hideLabel',
+      'multiple',
+      'calculateValue',
+      'validate',
+      'hidden',
+      'customConditional',
+    ]);
+  });
+
+  return valueComponentSettingsByComponentPath;
+};
+
+const getValueComponentRequiredSettings = (valueComponentsByComponentPath) => {
+  return {
+    label: 'Value:',
+    key: 'value',
+    placeholder: 'Enter Compared Value',
+    input: true,
+    typeChangeEnabled: true,
+    logic: [
+      {
+        name: 'check if row component is defined',
+        trigger: {
+          type: 'javascript',
+          javascript: 'result = true || row.component;',
+        },
+        actions: [
+          {
+            name: 'change value component',
+            type: 'mergeComponentSchema',
+            schemaDefinition: `
+            const valueComponentsByComponentPath = ${JSON.stringify(valueComponentsByComponentPath)};
+            const valueComponent = valueComponentsByComponentPath[row.component] || { type: 'textfield' };
+            
+            if (valueComponent.type !== 'datetime') {
+              valueComponent.widget = null;
+            }
+            
+            schema = {
+              ...valueComponent,
+              ..._.pick(component, [
+                'label', 'key', 'placeholder', 'input', 'typeChangeEnabled', 'logic', 'customConditional'
+              ])
+            };
+          `,
+          },
+        ],
+      },
+      {
+        name: 'clear value on empty operator',
+        trigger: {
+          type: 'javascript',
+          javascript: 'result = !row.operator && row[component.key];',
+        },
+        actions: [
+          {
+            name: 'clear value',
+            type: 'customAction',
+            customAction: 'instance.resetValue()',
+          },
+        ],
+      },
+    ],
+    customConditional: `
+      const singleOperators = ${JSON.stringify(operatorsWithNoValue)};
+      show = !_.includes(singleOperators, row.operator);
+    `,
+  };
+};
+
+module.exports = {
+  ConditionOperators,
+  filterComponentsForConditionComponentFieldOptions,
+  conditionOperatorsByComponentType,
+  allConditionOperatorsOptions,
+  operatorsWithNoValue,
+  getValueComponentsForEachFormComponent,
+  getValueComponentRequiredSettings,
+};

--- a/test/actions.js
+++ b/test/actions.js
@@ -2787,7 +2787,7 @@ module.exports = (app, template, hook) => {
           });
       });
 
-      if (!docker) 
+      if (!docker)
       it('A deleted Action should remain in the database', (done) => {
         const formio = hook.alter('formio', app.formio);
         formio.actions.model.findOne({_id: tempAction._id})
@@ -3406,6 +3406,1310 @@ module.exports = (app, template, hook) => {
 
             done();
           });
+      });
+    });
+
+    describe('Extended Conditional Logic Tests', () => {
+      let helper = null;
+      let action = null;
+      it('Create the forms', (done) => {
+        const owner = (app.hasProjects || docker) ? template.formio.owner : template.users.admin;
+        helper = new Helper(owner);
+        helper
+          .project()
+          .form('actionsExtendedConditionalForm', [
+            {
+              label: 'Text Field',
+              applyMaskOn: 'change',
+              tableView: true,
+              key: 'textField',
+              type: 'textfield',
+              input: true,
+            },
+            {
+              label: 'Number',
+              applyMaskOn: 'change',
+              mask: false,
+              tableView: false,
+              delimiter: false,
+              requireDecimal: false,
+              inputFormat: 'plain',
+              truncateMultipleSpaces: false,
+              key: 'number',
+              type: 'number',
+              input: true,
+            },
+            {
+              label: 'Select',
+              widget: 'choicesjs',
+              tableView: true,
+              data: {
+                values: [
+                  {
+                    label: 'Apple',
+                    value: 'apple',
+                  },
+                  {
+                    label: 'Banana',
+                    value: 'banana',
+                  },
+                ],
+              },
+              key: 'select',
+              type: 'select',
+              input: true,
+            },
+            {
+              label: 'Date / Time',
+              tableView: false,
+              datePicker: {
+                disableWeekends: false,
+                disableWeekdays: false,
+              },
+              enableMinDateInput: false,
+              enableMaxDateInput: false,
+              key: 'dateTime',
+              type: 'datetime',
+              input: true,
+              widget: {
+                type: 'calendar',
+                displayInTimezone: 'viewer',
+                locale: 'en',
+                useLocaleSettings: false,
+                allowInput: true,
+                mode: 'single',
+                enableTime: true,
+                noCalendar: false,
+                format: 'yyyy-MM-dd hh:mm a',
+                hourIncrement: 1,
+                minuteIncrement: 1,
+                time_24hr: false,
+                minDate: null,
+                disableWeekends: false,
+                disableWeekdays: false,
+                maxDate: null,
+              },
+            },
+            {
+              label: 'Checkbox',
+              tableView: false,
+              key: 'checkbox',
+              type: 'checkbox',
+              input: true,
+            },
+            {
+              label: 'Currency',
+              applyMaskOn: 'change',
+              mask: false,
+              spellcheck: true,
+              tableView: false,
+              currency: 'USD',
+              inputFormat: 'plain',
+              truncateMultipleSpaces: false,
+              key: 'currency',
+              type: 'currency',
+              input: true,
+              delimiter: true,
+            },
+            {
+              label: 'Select Boxes',
+              optionsLabelPosition: 'right',
+              tableView: false,
+              values: [
+                {
+                  label: 'a',
+                  value: 'a',
+                  shortcut: '',
+                },
+                {
+                  label: 'b',
+                  value: 'b',
+                  shortcut: '',
+                },
+                {
+                  label: 'c',
+                  value: 'c',
+                  shortcut: '',
+                },
+              ],
+              key: 'selectBoxes',
+              type: 'selectboxes',
+              input: true,
+              inputType: 'checkbox',
+            },
+            {
+              label: 'Radio',
+              optionsLabelPosition: 'right',
+              inline: false,
+              tableView: false,
+              values: [
+                {
+                  label: 'Val1',
+                  value: 'val1',
+                  shortcut: '',
+                },
+                {
+                  label: 'Val2',
+                  value: 'val2',
+                  shortcut: '',
+                },
+                {
+                  label: 'Val3',
+                  value: 'val3',
+                  shortcut: '',
+                },
+              ],
+              key: 'radio',
+              type: 'radio',
+              input: true,
+            },
+            {
+              label: 'Container',
+              tableView: false,
+              key: 'container',
+              type: 'container',
+              input: true,
+              components: [
+                {
+                  label: 'Text Field',
+                  applyMaskOn: 'change',
+                  tableView: true,
+                  key: 'textField',
+                  type: 'textfield',
+                  input: true,
+                },
+              ],
+            },
+            {
+              label: 'Data Grid',
+              reorder: false,
+              addAnotherPosition: 'bottom',
+              layoutFixed: false,
+              enableRowGroups: false,
+              initEmpty: false,
+              tableView: false,
+              defaultValue: [
+                {},
+              ],
+              key: 'dataGrid',
+              type: 'datagrid',
+              input: true,
+              components: [
+                {
+                  label: 'Data',
+                  applyMaskOn: 'change',
+                  tableView: true,
+                  key: 'data',
+                  type: 'textfield',
+                  input: true,
+                },
+              ],
+            },
+            {
+              type: 'button',
+              label: 'Submit',
+              key: 'submit',
+              disableOnInvalid: true,
+              input: true,
+              tableView: false,
+            },
+          ])
+          .execute((err) => {
+            if (err) {
+              return done(err);
+            }
+
+            helper.getActions('actionsExtendedConditionalForm', (err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              assert.equal(res.length, 1);
+              action = res[0];
+              assert.equal(action.name, 'save');
+
+              done();
+            });
+          });
+      });
+
+      it('Test IsEqual operator with Number', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'number',
+              operator: 'isEqual',
+              value: 12,
+            }
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              textField: 'test',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  textField: 'test',
+                  number: 12,
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test IsEqual operator with SelectBoxes', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'selectBoxes',
+              operator: 'isEqual',
+              value: 'a',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              selectBoxes: {
+                a: false,
+                b: true,
+                c: false,
+              }
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  selectBoxes: {
+                    a: true,
+                    b: false,
+                    c: true,
+                  }
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test IsEqual operator with Checkbox', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'checkbox',
+              operator: 'isEqual',
+              value: true,
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              checkbox: false,
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  checkbox: true,
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test IsEqual operator with Radio', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'radio',
+              operator: 'isEqual',
+              value: 'val1',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              radio: 'val2',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  radio: 'val1',
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test GreaterThan operator', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'number',
+              operator: 'greaterThan',
+              value: 20,
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              number: 20,
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  number: 21,
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test GreaterThanOrEqual operator', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'number',
+              operator: 'greaterThanOrEqual',
+              value: 20,
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              number: null,
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  number: 20,
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test LessThan operator', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'number',
+              operator: 'lessThan',
+              value: 20,
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              number: 40,
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  number: 19,
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test LessThanOrEqual operator', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'number',
+              operator: 'lessThanOrEqual',
+              value: 20,
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              number: 23,
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  number: 20,
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test Includes operator', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'textField',
+              operator: 'includes',
+              value: 'test',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              textField: 'Nothing',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  textField: 'Nothing test anything'
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test NotIncludes operator', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'textField',
+              operator: 'notIncludes',
+              value: 'test',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              textField: 'Nothing test',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  textField: 'something'
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test StartsWith operator', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'textField',
+              operator: 'startsWith',
+              value: 'test',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              textField: 'Somethingtest',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  textField: 'testSomething'
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test EndsWith operator', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'textField',
+              operator: 'endsWith',
+              value: 'test',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              textField: 'testSomething',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  textField: 'Somethingtest'
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test IsEmpty operator with TextField', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'textField',
+              operator: 'isEmpty',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              textField: 'Tee',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  textField: ''
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  helper
+                    .submission({
+                      textField: '     '
+                    })
+                    .execute((err) => {
+                      if (err) {
+                        return done(err);
+                      }
+
+                      const submission = helper.getLastSubmission();
+                      assert(submission.hasOwnProperty('_id'));
+
+                      done();
+                    });
+                });
+            });
+        });
+      });
+
+      it('Test IsEmpty operator with Number', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'number',
+              operator: 'isEmpty',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              number: 0,
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  number: null
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  helper
+                    .submission({
+                      number: ''
+                    })
+                    .execute((err) => {
+                      if (err) {
+                        return done(err);
+                      }
+
+                      const submission = helper.getLastSubmission();
+                      assert(submission.hasOwnProperty('_id'));
+
+                      done();
+                    });
+                });
+            });
+        });
+      });
+
+      it('Test IsEmpty operator with SelectBoxes', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'selectBoxes',
+              operator: 'isEmpty',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              selectBoxes: {
+                a: false,
+                b: true,
+                c: false,
+              }
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  selectBoxes: {
+                    a: false,
+                    b: false,
+                    c: false,
+                  }
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test IsEmpty operator with DateTime', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'dateTime',
+              operator: 'isEmpty',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              dateTime: '2023-07-01T12:00:00+03:00',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  dateTime: '',
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test DateGreaterThan operator', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'dateTime',
+              operator: 'dateGreaterThan',
+              value: '2023-07-01T12:00:00.000Z',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              dateTime: '2023-07-01T12:00:00.000Z',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  dateTime: '2023-07-03T12:00:00.000Z',
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test DateGreaterThanOrEqual operator', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'dateTime',
+              operator: 'dateGreaterThanOrEqual',
+              value: '2023-07-01T12:00:00.000Z',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              dateTime: '2023-06-01T12:00:00.000Z',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  dateTime: '2023-07-01T12:00:00.000Z',
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test DateLessThan operator', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'dateTime',
+              operator: 'dateLessThan',
+              value: '2023-07-03T12:00:00.000Z',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              dateTime: '2023-07-03T12:00:00.000Z',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  dateTime: '2023-07-02T12:00:00.000Z',
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test DateLessThanOrEqual operator', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'dateTime',
+              operator: 'dateLessThanOrEqual',
+              value: '2023-07-03T12:00:00.000Z',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              dateTime: '2023-07-04T12:00:00.000Z',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  dateTime: '2023-07-03T12:00:00.000Z',
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test that action is going to be executed only when all of conditions are met', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'textField',
+              operator: 'isEqual',
+              value: 'Test',
+            },
+            {
+              component: 'number',
+              operator: 'isNotEqual',
+              value: 10,
+            },
+            {
+              component: 'checkbox',
+              operator: 'isEqual',
+              value: true,
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              textField: 'Test',
+              number: 11,
+              checkbox: false,
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  textField: 'Test',
+                  number: 11,
+                  checkbox: true,
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test that action is going to be executed when any of conditions are met', (done) => {
+        action.condition = {
+          conjunction: 'any',
+          conditions: [
+            {
+              component: 'textField',
+              operator: 'isEqual',
+              value: 'Test',
+            },
+            {
+              component: 'number',
+              operator: 'isNotEqual',
+              value: 10,
+            },
+            {
+              component: 'checkbox',
+              operator: 'isEqual',
+              value: true,
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              textField: 'apple',
+              number: 10,
+              checkbox: false,
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  textField: 'something',
+                  number: 11,
+                  checkbox: false,
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
       });
     });
   });


### PR DESCRIPTION
Reverts formio/formio#1623 which reverted the formio/formio#1596. The following description is a copy/paste of formio/formio#1596

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-6630

## Description

Previously, we had a form allowing to configure only 1 simple condition for executing form actions.
![image](https://github.com/formio/formio/assets/60643585/96f723e2-e8a0-462d-ae6a-b06da106101f)
Now we have more complex form allowing to combine different conditions and using different operators 
![image](https://github.com/formio/formio/assets/60643585/a0d76bf1-5edf-4332-ba42-1ff33aee97d1)

The idea was taken from our expanded UI for components conditions/logic.

## Dependencies

There is also a required PR for formio.js https://github.com/formio/formio.js/pull/5270

## How has this PR been tested?

Manually for now, automated tests are coming :)

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
