### PR TITLE
FIO-6630: Adds root level properties to action conditions

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -188,7 +188,7 @@ module.exports = (router) => {
         }
 
         async.eachSeries(actions, (action, cb) => {
-          this.shouldExecute(action, req).then(execute => {
+          this.shouldExecute(action, req, res).then(execute => {
             if (!execute) {
               return cb();
             }
@@ -222,7 +222,7 @@ module.exports = (router) => {
       });
     },
 
-    async shouldExecute(action, req) {
+    async shouldExecute(action, req, res) {
       const condition = action.condition;
       if (!condition) {
         return true;
@@ -297,7 +297,7 @@ module.exports = (router) => {
         // See if a condition is not established within the action.
         const field = condition.field || '';
         const eq = condition.eq || '';
-        const value = String(await getComponentValueFromRequest(req, field));
+        const value = String(await getComponentValueFromRequest(req, res, field));
         const compare = String(condition.value || '');
         debug.action(
           '\nfield', field,
@@ -325,7 +325,7 @@ module.exports = (router) => {
           if (!conditionComponentPath || !ConditionOperator) {
             return true;
           }
-          const value = await getComponentValueFromRequest(req, conditionComponentPath, isRootLevelProperty);
+          const value = await getComponentValueFromRequest(req, res, conditionComponentPath, isRootLevelProperty);
           let component;
           if (req.currentFormComponents && !isRootLevelProperty) {
             component = util.FormioUtils.getComponent(req.currentFormComponents, conditionComponentPath);
@@ -513,6 +513,49 @@ module.exports = (router) => {
                         key: 'component',
                         type: 'select',
                         input: true,
+                        logic: [
+                          {
+                            name: 'Show a tip when submission.created property is selected',
+                            trigger: {
+                              type: 'javascript',
+                              javascript: 'result = row.component === \'(submission).created\';\n',
+                            },
+                            actions: [
+                              {
+                                name: 'Show a tip',
+                                type: 'property',
+                                property: {
+                                  label: 'Description',
+                                  value: 'description',
+                                  type: 'string',
+                                },
+                                text: 'Notice that \'created\' property is not available when action is' +
+                                  ' triggered Before Create, so it won\'t be executed',
+                              },
+                            ],
+                          },
+                          {
+                            name: 'Show a tip when submission.modified property is selected',
+                            trigger: {
+                              type: 'javascript',
+                              javascript: 'result = row.component === \'(submission).modified\';\n',
+                            },
+                            actions: [
+                              {
+                                name: 'Show a tip',
+                                type: 'property',
+                                property: {
+                                  label: 'Description',
+                                  value: 'description',
+                                  type: 'string',
+                                },
+                                text: 'Notice that \'modified\' property is not available Before/After Create. It' +
+                                  ' also is not available or is equal to the last edit date Before Update and' +
+                                  ' Before/After Read. So make sure that you configure it properly.',
+                              },
+                            ],
+                          },
+                        ],
                       },
                       {
                         label: 'Is:',
@@ -528,7 +571,9 @@ module.exports = (router) => {
                           custom:`
                             const formComponents = ${JSON.stringify(flattenedComponents)};
                             const rootLevelProperties = ${JSON.stringify(rootLevelPropertiesOperatorsByPath)};
-                            const isRootLevelProperty = row.component && row.component.startsWith('(submission).'); 
+                            const isRootLevelProperty = row.component &&
+                              row.component.startsWith &&
+                              row.component.startsWith('(submission).'); 
                             const conditionComponent = formComponents[row.component];
                             let componentType = conditionComponent ? conditionComponent.type : 'base';
                             if (isRootLevelProperty) {
@@ -680,12 +725,15 @@ module.exports = (router) => {
     }
   }
 
-  async function getComponentValueFromRequest(req, field, isRootLevelProperty) {
+  async function getComponentValueFromRequest(req, res, field, isRootLevelProperty) {
     const isDelete = req.method.toUpperCase() === 'DELETE';
     const deletedSubmission = isDelete ? await getDeletedSubmission(req): false;
     const fieldPath = isRootLevelProperty ? '' : 'data.';
+
     const value = isDelete ? _.get(deletedSubmission, `${fieldPath}${field}`, '') :
+      _.get(res, `resource.item.${fieldPath}${field}`, '') ||
       _.get(req, `body.${fieldPath}${field}`, '');
+
     return value;
   }
 

--- a/src/util/conditionOperators/index.js
+++ b/src/util/conditionOperators/index.js
@@ -50,8 +50,8 @@ const conditionOperatorsByComponentType = {
     IsNotEmptyValue.operatorKey,
   ]};
 
-Object.keys(Formio.Components.components).forEach((type) => {
-  const component = Formio.Components.components[type];
+Object.keys(Formio.AllComponents).forEach((type) => {
+  const component = Formio.AllComponents[type];
   const operators = component && component.serverConditionSettings ? component.serverConditionSettings.operators : null;
   if (operators) {
     conditionOperatorsByComponentType[type] = operators;
@@ -71,7 +71,28 @@ const rootLevelProperties = [
       'dateLessThanOrEqual',
       'dateGreaterThanOrEqual',
     ],
-    valueComponent: Formio.Components.components.datetime.schema() || {type: 'datetime'},
+    valueComponent: {
+      type: 'datetime',
+      widget: {
+        type: 'calendar',
+        displayInTimezone: 'viewer',
+        locale: 'en',
+        useLocaleSettings: false,
+        allowInput: true,
+        mode: 'single',
+        enableTime: true,
+        noCalendar: false,
+        format: 'yyyy-MM-dd hh:mm a',
+        hourIncrement: 1,
+        minuteIncrement: 1,
+        // eslint-disable-next-line camelcase
+        time_24hr: false,
+        minDate: null,
+        disableWeekends: false,
+        disableWeekdays: false,
+        maxDate: null,
+      },
+    },
   },
   {
     label: 'Modified',
@@ -84,18 +105,35 @@ const rootLevelProperties = [
       'dateLessThanOrEqual',
       'dateGreaterThanOrEqual',
     ],
-    valueComponent: Formio.Components.components.datetime.schema() || {type: 'datetime'},
+    valueComponent: {
+  type: 'datetime',
+    widget: {
+    type: 'calendar',
+      displayInTimezone: 'viewer',
+      locale: 'en',
+      useLocaleSettings: false,
+      allowInput: true,
+      mode: 'single',
+      enableTime: true,
+      noCalendar: false,
+      format: 'yyyy-MM-dd hh:mm a',
+      hourIncrement: 1,
+      minuteIncrement: 1,
+      // eslint-disable-next-line camelcase
+      time_24hr: false,
+      minDate: null,
+      disableWeekends: false,
+      disableWeekdays: false,
+      maxDate: null,
+  },
+},
   },
   {
     label: 'State',
     value: '(submission).state',
     operators: [
-      'isDateEqual',
-      'isNotDateEqual',
-      'dateLessThan',
-      'dateGreaterThan',
-      'dateLessThanOrEqual',
-      'dateGreaterThanOrEqual',
+      'isEqual',
+      'isNotEqual',
     ],
     valueComponent: {
       valueType: 'string',
@@ -201,7 +239,7 @@ const getValueComponentsForEachFormComponent = (flattenedComponents) => {
   Object.keys(flattenedComponents).forEach((path) => {
     const componentSchema = flattenedComponents[path];
     const component = componentSchema && componentSchema.type
-      ? Formio.Components.components[componentSchema.type]
+      ? Formio.AllComponents[componentSchema.type]
       : null;
     const getValueComponent = component && component.serverConditionSettings ?
       component.serverConditionSettings.valueComponent :
@@ -249,7 +287,7 @@ const getValueComponentRequiredSettings = (valueComponentsByFieldPath) => {
         name: 'check if row component is defined',
         trigger: {
           type: 'javascript',
-          javascript: 'result = true || row.component;',
+          javascript: 'result = !!row.component;',
         },
         actions: [
           {
@@ -258,6 +296,10 @@ const getValueComponentRequiredSettings = (valueComponentsByFieldPath) => {
             schemaDefinition: `
             const valueComponentsByFieldPath = ${JSON.stringify(valueComponentsByFieldPath)};
             const valueComponent = valueComponentsByFieldPath[row.component] || { type: 'textfield' };
+            
+            if (valueComponent.type !== 'datetime') {
+              valueComponent.widget = null;
+            }
             
             schema = {
               ...valueComponent,


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7235

## Description

Adds State, Created and Modified properties to the When select dropdown of expanded action conditions. That allows to configure actions based on when the submission was created/updated or on its state. 

Also now it try to get value from res.resource.item instead of req.body which won't have a submission data on most triggers except of After Create one. If there is no res.resource.item, it will fallback to the req.body. 
When user selects Created/Modified fields, the description of the select dropdown will be updated to warn user that those fields won't be persitent within a submission on some trigger types.

## Dependencies

Since this Expanded Actions UI feature was moved to a later release, we need to merge it first cause this PR is an extension for that feature. https://github.com/formio/formio/pull/1624

## How has this PR been tested?

Yes, I performed manual testing.

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
