### PR TITLE
bugfix: add catch block to nunjucks injection

### DIFF
--- a/src/util/email.js
+++ b/src/util/email.js
@@ -225,7 +225,8 @@ module.exports = (formio) => {
       }
 
       return resolve(injectedEmail);
-    });
+    })
+    .catch(reject);
   });
 
   /**


### PR DESCRIPTION
## Link to Jira Ticket

n/a

## Description

Our production servers began thrashing 9/14/23 with the message 
```
Uncaught exception:
current-api-server-1  | [UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "Invalid response.".] {
current-api-server-1  |   code: 'ERR_UNHANDLED_REJECTION'
current-api-server-1  | }
current-api-server-1  | UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "Invalid response.".
```

Although the error lacks a descriptive call stack, I believe this is due to the email utility's `nunjucksInjector` not having a catch callback.

FWIW, this email utility could use a refactor; it looks like we're wrapping the Promises returned by functions like `fetch` needlessly in other Promise objects, which is [the explicit construction anti-pattern](https://saturncloud.io/blog/what-is-the-explicit-promise-construction-antipattern-and-how-do-i-avoid-it/#what-is-the-explicit-promise-construction-antipattern) and wastes event cycles.

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
