### PR TITLE
FIO-7338: Fixes server crush when form id is 'undefined'

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,7 @@
   "root": true,
   "extends": "eslint-config-formio",
   "parserOptions": {
-    "ecmaVersion": 2018
+    "ecmaVersion": 2020
   },
   "env": {
     "node": true,

--- a/src/middleware/params.js
+++ b/src/middleware/params.js
@@ -11,20 +11,26 @@ module.exports = (router) => {
     // Split the request url into its corresponding parameters.
     const params = _.assign(util.getUrlParams(req.url), util.getUrlParams(req.baseUrl));
 
-    // Get the formId from the request url.
-    const formId = params.hasOwnProperty('form') && params.form !== 'undefined'
-      ? params.form
-      : null;
+    if (params.hasOwnProperty('form') && util.checkIsUndefinedOrNullString(params.form)) {
+      return res.status(400).send('Invalid form id provided.');
+    }
 
     // Get the formId from the request url.
-    let subId = params.hasOwnProperty('submission') && params.form !== 'undefined'
-      ? params.submission
-      : null;
+    const formId = params.form ?? null;
+
+    if (params.hasOwnProperty('submission') && util.checkIsUndefinedOrNullString(params.submission)) {
+      return res.status(400).send('Invalid submission id provided.');
+    }
+
+    // Get the subId from the request url.
+    let subId = params.submission ?? null;
+
+    if (params.hasOwnProperty('role') && util.checkIsUndefinedOrNullString(params.role)) {
+      return res.status(400).send('Invalid role id provided.');
+    }
 
     // Get the roleId from the request url.
-    const roleId = params.hasOwnProperty('role') && params.role !== 'undefined'
-      ? params.role
-      : null;
+    const roleId = params.role ?? null;
 
     // FA-993 - Update the request to check submission index in the case of submission exports.
     if (subId === null && formId !== null && params.hasOwnProperty('export')) {

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -164,6 +164,16 @@ const Utils = {
   },
 
   /**
+   * Checks if string is 'undefined' or 'null'.
+   *
+   * @param {String} str
+   * @returns {Boolean}
+   */
+  checkIsUndefinedOrNullString(str) {
+    return ['undefined', 'null'].includes(str);
+  },
+
+  /**
    * Create a sub response object that only handles errors.
    *
    * @param res

--- a/test/form.js
+++ b/test/form.js
@@ -672,6 +672,24 @@ module.exports = function(app, template, hook) {
           });
       });
 
+      it('Should return error if undefined form id provided', done => {
+        request(app)
+          .get(hook.alter('url', '/form/undefined', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .expect(400)
+          .expect('Invalid form id provided.')
+          .end(done);
+      });
+
+      it('Should return error if null form id provided', done => {
+        request(app)
+          .get(hook.alter('url', '/form/null', template))
+          .set('x-jwt-token', template.users.admin.token)
+          .expect(400)
+          .expect('Invalid form id provided.')
+          .end(done);
+      });
+
       it('Cant make a Form with invalid Form component keys', function(done) {
         async.each([
           '', 'è', 'é', 'ê', 'ë', 'ē', 'ė', 'ę', 'ÿ', 'û',

--- a/test/form.js
+++ b/test/form.js
@@ -674,7 +674,7 @@ module.exports = function(app, template, hook) {
 
       it('Should return error if undefined form id provided', done => {
         request(app)
-          .get(hook.alter('url', '/form/undefined', template))
+          .get('/form/undefined')
           .set('x-jwt-token', template.users.admin.token)
           .expect(400)
           .expect('Invalid form id provided.')
@@ -683,7 +683,7 @@ module.exports = function(app, template, hook) {
 
       it('Should return error if null form id provided', done => {
         request(app)
-          .get(hook.alter('url', '/form/null', template))
+          .get('/form/null')
           .set('x-jwt-token', template.users.admin.token)
           .expect(400)
           .expect('Invalid form id provided.')

--- a/test/roles.js
+++ b/test/roles.js
@@ -292,23 +292,21 @@ module.exports = function(app, template, hook) {
 
       it('Should return error if undefined role id provided', done => {
         request(app)
-          .get(hook.alter('url', '/role/undefined'))
+          .get('/role/undefined')
           .set('x-jwt-token', template.users.admin.token)
           .expect(400)
           .expect('Invalid role id provided.')
           .end(done);
       });
-
 
       it('Should return error if null role id provided', done => {
         request(app)
-          .get(hook.alter('url', '/role/null'))
+          .get('/role/null')
           .set('x-jwt-token', template.users.admin.token)
           .expect(400)
           .expect('Invalid role id provided.')
           .end(done);
       });
-
     });
 
     describe('Role Normalization', function() {

--- a/test/roles.js
+++ b/test/roles.js
@@ -289,6 +289,26 @@ module.exports = function(app, template, hook) {
             done();
           });
       });
+
+      it('Should return error if undefined role id provided', done => {
+        request(app)
+          .get(hook.alter('url', '/role/undefined'))
+          .set('x-jwt-token', template.users.admin.token)
+          .expect(400)
+          .expect('Invalid role id provided.')
+          .end(done);
+      });
+
+
+      it('Should return error if null role id provided', done => {
+        request(app)
+          .get(hook.alter('url', '/role/null'))
+          .set('x-jwt-token', template.users.admin.token)
+          .expect(400)
+          .expect('Invalid role id provided.')
+          .end(done);
+      });
+
     });
 
     describe('Role Normalization', function() {
@@ -949,7 +969,7 @@ module.exports = function(app, template, hook) {
         accessHelper.template.roles['access-manager']._id.toString(),
         accessHelper.template.roles.authenticated._id.toString()
       ];
-    
+
       accessHelper.submission('access-manager', manager, manager).execute((err) => {
         if (err) {
           return done(err);
@@ -963,17 +983,17 @@ module.exports = function(app, template, hook) {
         done();
       });
     });
-    
+
     it('Should allow the manager to remove a role.', (done) => {
       manager.roles = [
         accessHelper.template.roles['access-manager']._id.toString(),
       ];
-    
+
       accessHelper.submission('access-manager', manager, manager).execute((err) => {
         if (err) {
           return done(err);
         }
-        const updated = accessHelper.getLastSubmission();       
+        const updated = accessHelper.getLastSubmission();
         assert.deepEqual(updated.roles, [
           accessHelper.template.roles['access-manager']._id.toString()
         ]);
@@ -1013,7 +1033,7 @@ module.exports = function(app, template, hook) {
 
           async.series(
             [
-              (next) => accessHelper.deleteRole('access-manager', next), 
+              (next) => accessHelper.deleteRole('access-manager', next),
               (next) => accessHelper.deleteRole('access-employee', next)
             ],
             (err) => {

--- a/test/submission.js
+++ b/test/submission.js
@@ -4285,6 +4285,27 @@ module.exports = function(app, template, hook) {
           });
       });
     });
+
+    describe('Check errors appearing for undefined/null submission ids', function() {
+      it('Should return error if undefined submission id provided', done => {
+        request(app)
+          .get(hook.alter('url', '/submission/undefined'))
+          .set('x-jwt-token', helper.owner.token)
+          .expect(400)
+          .expect('Invalid submission id provided.')
+          .end(done);
+      });
+
+      it('Should return error if null submission id provided', done => {
+        request(app)
+          .get(hook.alter('url', '/submission/null'))
+          .set('x-jwt-token', helper.owner.token)
+          .expect(400)
+          .expect('Invalid submission id provided.')
+          .end(done);
+      })
+    })
+
   });
 
   describe('Nested Submissions', function() {

--- a/test/submission.js
+++ b/test/submission.js
@@ -4286,10 +4286,10 @@ module.exports = function(app, template, hook) {
       });
     });
 
-    describe('Check errors appearing for undefined/null submission ids', function() {
+    describe('Check errors appearing for undefined/null submission ids', () => {
       it('Should return error if undefined submission id provided', done => {
         request(app)
-          .get(hook.alter('url', '/submission/undefined'))
+          .get('/submission/undefined')
           .set('x-jwt-token', helper.owner.token)
           .expect(400)
           .expect('Invalid submission id provided.')
@@ -4298,14 +4298,13 @@ module.exports = function(app, template, hook) {
 
       it('Should return error if null submission id provided', done => {
         request(app)
-          .get(hook.alter('url', '/submission/null'))
+          .get('/submission/null')
           .set('x-jwt-token', helper.owner.token)
           .expect(400)
           .expect('Invalid submission id provided.')
           .end(done);
       })
-    })
-
+    });
   });
 
   describe('Nested Submissions', function() {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7338

## Description

**What changed?**

Previously, passing an `undefined` form id could sometimes crash the server. Now there's a check for form id, submission id and role id not to be equal to `undefined` or `null` strings. In case of being equal, an error would be returned from the API.

**Why have you chosen this solution?**

`params` middleware seemed to be a good place to make the check, since it's triggered nearly at the beginning and parses not only form id, but also submission id and role id from request params. 

## Dependencies

None

## How has this PR been tested?

I've added automated tests

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
