### PR TITLE
FIO-7330: fix bug of displaying settings for restricted fields

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -599,6 +599,7 @@ module.exports = (router) => {
             tree: false,
             key: 'conditions',
             legend: 'Action Execution',
+            hidden: mainSettings.components.length && mainSettings.components.every(({type})=> type === 'hidden'),
             components: mainSettings.components
           },
           {
@@ -730,7 +731,7 @@ module.exports = (router) => {
       });
 
       try {
-        getSettingsForm(action, req, (err, settings) => {
+        getSettingsForm(info, req, (err, settings) => {
           if (err) {
             router.formio.log('Error, can\'t get action settings', req, err);
             return res.status(400).send(err);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7330

## Description

**What changed?**

Previously, action settings form fields with restricted access won't be hidden and sometimes changing them could make the server crush. This PR fixes hiding fields with restricted access.

## Dependencies

[formio-server:1368](https://github.com/formio/formio-server/pull/1368)

## How has this PR been tested?

I've added automated test

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
