### PR TITLE
FIO-7491: fixed an issue where dataTable component with resource data type does not work after exporting/importing

### DIFF
--- a/src/templates/export.js
+++ b/src/templates/export.js
@@ -167,6 +167,7 @@ module.exports = (router) => {
             assignForm(_map, component.data);
             assignResource(_map, component);
             assignResource(_map, component.data);
+            assignResource(_map, component.fetch);
             if (component && component.data && component.data.project) {
               component.data.project = 'project';
             }

--- a/src/templates/import.js
+++ b/src/templates/import.js
@@ -270,6 +270,16 @@ module.exports = (router) => {
         changed = true;
       }
 
+      // Update resource machineNames for dataTable components with the resource data type.
+      if (
+        (component.type === 'datatable') &&
+        (component.fetch && component.fetch.dataSrc === 'resource') &&
+        resourceMachineNameToId(template, component.fetch)
+      ) {
+        hook.alter(`importComponent`, template, component.fetch);
+        changed = true;
+      }
+
       // Allow importing of components.
       if (hook.alter(`importComponent`, template, component)) {
         changed = true;

--- a/test/fixtures/templates/testDataTableWithResource.json
+++ b/test/fixtures/templates/testDataTableWithResource.json
@@ -1,0 +1,103 @@
+{
+  "title": "Test Data Table With Resource",
+  "version": "2.0.0",
+  "name": "testDataTableWithResource",
+  "roles": {
+  },
+  "forms": {
+    "formWithDt": {
+      "title": "form with DT",
+      "type": "form",
+      "name": "formWithDt",
+      "path": "formwithdt",
+      "display": "form",
+      "tags": [],
+      "settings": {},
+      "components": [
+        {
+          "label": "Data Table",
+          "sortable": true,
+          "filterable": true,
+          "clipCells": false,
+          "itemsPerPage": 10,
+          "tableView": false,
+          "fetch": {
+            "enableFetch": true,
+            "components": [
+              {
+                "path": "name",
+                "key": "name"
+              },
+              {
+                "path": "age",
+                "key": "age"
+              }
+            ],
+            "dataSrc": "resource",
+            "resource": "resourceFormForDt",
+            "sort": {
+              "defaultQuery": ""
+            }
+          },
+          "key": "dataTable",
+          "type": "datatable",
+          "input": true,
+          "submitSelectedRows": false,
+          "allowCaching": true,
+          "components": []
+        },
+        {
+          "type": "button",
+          "label": "Submit",
+          "key": "submit",
+          "disableOnInvalid": true,
+          "input": true,
+          "tableView": false
+        }
+      ]
+    }
+  },
+  "actions": {},
+  "resources": {
+    "resourceFormForDt": {
+      "title": "resource form for DT",
+      "type": "resource",
+      "name": "resourceFormForDt",
+      "path": "resourceformfordt",
+      "display": "form",
+      "tags": [],
+      "settings": {},
+      "components": [
+        {
+          "label": "Name",
+          "applyMaskOn": "change",
+          "tableView": true,
+          "key": "name",
+          "type": "textfield",
+          "input": true
+        },
+        {
+          "label": "Age",
+          "applyMaskOn": "change",
+          "mask": false,
+          "tableView": false,
+          "delimiter": false,
+          "requireDecimal": false,
+          "inputFormat": "plain",
+          "truncateMultipleSpaces": false,
+          "key": "age",
+          "type": "number",
+          "input": true
+        },
+        {
+          "type": "button",
+          "label": "Submit",
+          "key": "submit",
+          "disableOnInvalid": true,
+          "input": true,
+          "tableView": false
+        }
+      ]
+    }
+  }
+}

--- a/test/templates.js
+++ b/test/templates.js
@@ -3755,5 +3755,54 @@ module.exports = (app, template, hook) => {
       });
     });
 
+    describe('Template With Resource DataTable', function() {
+      let testTemplate = require('./fixtures/templates/testDataTableWithResource.json');
+      let _template = _.cloneDeep(testTemplate);
+      let project;
+
+      describe('Import', function() {
+        it('Should be able to bootstrap the template', function(done) {
+          importer.import.template(_template, alters, (err, data) => {
+            if (err) {
+              return done(err);
+            }
+            project = data;
+            done();
+          });
+        });
+
+        it ('The Data Table Fetch Resource should be replaced with valid resource id', function(done) {
+          assert.equal(project.forms.formWithDt.components[0].fetch.resource, project.resources.resourceFormForDt._id.toString());
+          done();
+        });
+      });
+
+      describe('Export', function() {
+        let exportData = {};
+
+        it ('Should be able to export project', function(done) {
+          importer.export(project, (err, data) => {
+            if (err) {
+              return done(err);
+            }
+            exportData = data;
+            return done();
+          });
+        });
+
+        it ('The Data Table Fetch Resource should be replaced with resource name', function(done) {
+          assert.equal(exportData.forms.formWithDt.components[0].fetch.resource,  exportData.resources.resourceFormForDt.name);
+          done();
+        });
+      });
+
+      before(function(done) {
+        template.clearData(done);
+      });
+
+      after(function(done) {
+        template.clearData(done);
+      });
+    });
   });
 };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7491

## Description

**What changed?**

Added logic that 
- replaces the DT resource id by machine name when exporting the template with resource DT 
- replaces the DT resource machine name with valid resource id when importing the template.

## How has this PR been tested?

manually + tests added

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
