### PR TITLE
FIO-7538: Change vm-utils link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "superagent-retry": "^0.6.0",
     "through": "^2.3.8",
     "vanilla-text-mask": "^5.1.1",
-    "vm-utils": "https://github.com/formio/vm-utils.git#1.0.0"
+    "vm-utils": "https://github.com/formio/vm-utils.git#1.0.0-rc.1"
   },
   "devDependencies": {
     "eslint": "^8.25.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "superagent-retry": "^0.6.0",
     "through": "^2.3.8",
     "vanilla-text-mask": "^5.1.1",
-    "vm-utils": "https://github.com/formio/vm-utils.git#main"
+    "vm-utils": "https://github.com/formio/vm-utils.git#1.0.0"
   },
   "devDependencies": {
     "eslint": "^8.25.0",


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7538

## Description

**What changed?**

vm-utils was pulling directly from master. Changes were made to master that caused the tests to start failing. This PR puts vm-utils back to a version prior to the changes that were made in master.

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
