### PR TITLE
FIO-7514: fixed an issue where submission reference object is not attached to the value of select component with reference enabled

### DIFF
--- a/src/actions/properties/reference.js
+++ b/src/actions/properties/reference.js
@@ -264,7 +264,6 @@ module.exports = (router) => {
         var queues = [];
         util.FormioUtils.eachComponent(form.components, (subcomp, subpath) => {
           if (subcomp.reference) {
-            console.log(3333);
             queues.push(buildPipeline(subcomp, `${path}.data.${subpath}`, req, res).then((subpipe) => {
               pipeline = pipeline.concat(subpipe);
             }));
@@ -302,7 +301,6 @@ module.exports = (router) => {
         if (!idQuery) {
           return Promise.resolve();
         }
-console.log(2222);
         return loadReferences(component, {
           _id: idQuery,
           limit: 10000000

--- a/src/actions/properties/reference.js
+++ b/src/actions/properties/reference.js
@@ -34,6 +34,9 @@ module.exports = (router) => {
       delete sub.req.subId;
     }
 
+    //not allow to override subrequest subId with parent submissionId
+    _.unset(sub.req.params, 'submissionId');
+
     sub.req.url = '/form/:formId/submission';
     sub.req.query = subQuery || {};
     sub.req.method = 'GET';
@@ -261,6 +264,7 @@ module.exports = (router) => {
         var queues = [];
         util.FormioUtils.eachComponent(form.components, (subcomp, subpath) => {
           if (subcomp.reference) {
+            console.log(3333);
             queues.push(buildPipeline(subcomp, `${path}.data.${subpath}`, req, res).then((subpipe) => {
               pipeline = pipeline.concat(subpipe);
             }));
@@ -298,7 +302,7 @@ module.exports = (router) => {
         if (!idQuery) {
           return Promise.resolve();
         }
-
+console.log(2222);
         return loadReferences(component, {
           _id: idQuery,
           limit: 10000000


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7514

## Description

**What changed?**

When the subrequest for reference submission is made, the submissionId param of the main submission request overrides the reference subId and the submission subrequest returns the 404 error. This PR unsets submissionId param from subrequest to prevent this situation.

https://github.com/formio/formio.js/pull/5429

## How has this PR been tested?

Manually

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
