### PR TITLE
FIO-7330: Fixes action settings endpoint crushing

### DIFF
--- a/src/actions/SaveSubmission.js
+++ b/src/actions/SaveSubmission.js
@@ -44,7 +44,7 @@ module.exports = function(router) {
           form: req.params.formId,
           required: false
         }
-      ]));
+      ], util.skipHookIfNotExists));
     }
 
     /**

--- a/test/actions.js
+++ b/test/actions.js
@@ -700,6 +700,23 @@ module.exports = (app, template, hook) => {
           });
       });
 
+      it('Should hide fields in action settings form if access to them is restricted', (done) => {
+        request(app)
+         .get(hook.alter('url', `/form/${webhookForm._id}/actions/save`, template))
+         .set('x-jwt-token', template.users.admin.token)
+         .expect('Content-Type', /json/)
+         .expect(200)
+         .end((err, res) => {
+           if (err) {
+             return done(err);
+           }
+           const components = res.body?.settingsForm?.components ?? [];
+           const actionExecutionComponent = components.find(x=> x.legend ==="Action Execution");
+           assert.equal(actionExecutionComponent.hidden, true);
+           done();
+       });
+     })
+
       it('Should send a webhook with update data.', (done) => {
         webhookHandler = (body) => {
           body = hook.alter('webhookBody', body);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7330

## Description

**What changed?**

Previously, endpoint to get action settings would crush if `actionSettingsForm` not found, this PR adds skip for the hook if it's not found.

## Dependencies

None

## How has this PR been tested?

I've added automated test

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
