### PR TITLE
FIO 7522 Encrypted Fields Not Re-Encrypted to New DB Secret Formio

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,9 +137,6 @@ module.exports = function(config) {
         router.use(router.formio.middleware.params);
       }
 
-      // Check for need to re-encrypt data
-      router.formio.hook.invoke('init', 'checkEncryption', router.formio);
-
       // Add the db schema sanity check to each request.
       router.use(router.formio.update.sanityCheck);
 

--- a/index.js
+++ b/index.js
@@ -137,6 +137,8 @@ module.exports = function(config) {
         router.use(router.formio.middleware.params);
       }
 
+      router.formio.hook.invoke('init', 'checkEncryption', router.formio);
+
       // Add the db schema sanity check to each request.
       router.use(router.formio.update.sanityCheck);
 

--- a/index.js
+++ b/index.js
@@ -137,6 +137,7 @@ module.exports = function(config) {
         router.use(router.formio.middleware.params);
       }
 
+      // Check for need to re-encrypt data
       router.formio.hook.invoke('init', 'checkEncryption', router.formio);
 
       // Add the db schema sanity check to each request.

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -255,6 +255,11 @@ module.exports = function(formio) {
     }, Math.random() * 1000);
   };
 
+  const checkEncryption = function(next) {
+    formio.hook.alter('checkEncryption', formio, db);
+    next();
+  };
+
   /**
    * Check for certain mongodb features.
    * @param {*} next.
@@ -747,6 +752,7 @@ module.exports = function(formio) {
       lock,
       doConfigFormsUpdates,
       doUpdates,
+      checkEncryption,
       unlock
     ], function(err) {
       unlock(function() {

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -255,43 +255,6 @@ module.exports = function(formio) {
     }, Math.random() * 1000);
   };
 
-  const checkEncryption = function(next) {
-    if (config.mongoSecretOld) {
-      formio.util.log('DB Secret update required.');
-      const projects = db.collection('projects');
-      projects.find({}).forEach(function(project) {
-        if (project.settings_encrypted) {
-          try {
-            const settings = tools.decrypt(config.mongoSecretOld, project.settings_encrypted.buffer);
-            if (settings) {
-              /* eslint-disable camelcase */
-              projects.updateOne(
-                {_id: project._id},
-                {
-                  $set: {
-                    settings_encrypted: tools.encrypt(config.mongoSecret, settings)
-                  }
-                }
-              );
-              /* eslint-enable camelcase */
-            }
-          }
-          catch (err) {
-            debug.error(err);
-            formio.util.log(' > Unable to use old db secret key.');
-          }
-        }
-      },
-      function(err) {
-        formio.util.log(' > Finished updating db secret.\n');
-        next(err);
-      });
-    }
-    else {
-      return next();
-    }
-  };
-
   /**
    * Check for certain mongodb features.
    * @param {*} next.
@@ -779,7 +742,6 @@ module.exports = function(formio) {
       getSSL,
       connection,
       checkSetup,
-      checkEncryption,
       checkFeatures,
       getUpdates,
       lock,


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7522

## Description

**What changed?**

Removed DB_SECRET migration logic and added hook call.

**Why have you chosen this solution?**

Moves logic to server project

## Breaking Changes / Backwards Compatibility

None

## Dependencies

None

## How has this PR been tested?

Tested with supporting branch.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
