### PR TITLE
FIO-7829: Removed the flattened components which is not necessary wit…

### DIFF
--- a/src/middleware/submissionHandler.js
+++ b/src/middleware/submissionHandler.js
@@ -54,11 +54,10 @@ module.exports = (router, resourceName, resourceId) => {
           return done('Form not found.');
         }
 
-          req.currentForm = hook.alter('currentForm', form, req.body);
+        req.currentForm = hook.alter('currentForm', form, req.body);
 
         // Load all subforms as well.
         router.formio.cache.loadSubForms(req.currentForm, req, () => {
-          req.flattenedComponents = util.flattenComponents(form.components, true);
           return done();
         });
       }, true);


### PR DESCRIPTION
…h the changes to encryption and decryption.

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7829

## Description

Previously, we would keep a reference to "flattenedComponents" so that we could iterate through them and handle encryption. This did not work for deeply nested components, so we replaced it with the use of eachComponentData from our @formio/core library.

**Why have you chosen this solution?**

*Use this section to justify your choices*

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
