### PR TITLE
Modernize the Dockerfile to decouple from host machine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ ENV DEBUG=""
 
 # This will initialize the application based on
 # some questions to the user (login email, password, etc.)
-ENTRYPOINT [ "node", "main" ]
+ENTRYPOINT [ "node", "--no-node-snapshot", "main" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,14 @@
 # Use Node image, maintained by Docker:
 # hub.docker.com/r/_/node/
 FROM node:lts-alpine3.19
+
+# Copy source dependencies
+COPY src/ /app/src/
+COPY config/ /app/config
+COPY *.js /app/
+COPY *.txt /app/
+COPY package.json /app/
+
 WORKDIR /app
 
 # "bcrypt" requires python/make/g++, all must be installed in alpine
@@ -12,35 +20,17 @@ WORKDIR /app
 RUN apk update && \
     apk upgrade && \
     apk add make && \
-    apk add g++
+    apk add python3 && \
+    apk add g++ && \
+    apk add git
 
-# At least one buried package dependency is using a `git` path.
-# Hence we need to haul in git.
-RUN apk --update add git
 # Use https to avoid requiring ssh keys for public repos.
 RUN git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
 
-# Using an alternative package install location
-# to allow overwriting the /app folder at runtime
-# stackoverflow.com/a/13021677
-ENV NPM_PACKAGES=/.npm-packages \
-    PATH=$NPM_PACKAGES/bin:$PATH \
-    NODE_PATH=$NPM_PACKAGES/lib/node_modules:$NODE_PATH
-RUN echo "prefix = $NPM_PACKAGES" >> ~/.npmrc
-
-# Include details of the required dependencies
-COPY ./package.json $NPM_PACKAGES/
-COPY ./package-lock.json $NPM_PACKAGES/
-
 # Use "Continuous Integration" to install as-is from package-lock.json
-RUN npm ci --prefix=$NPM_PACKAGES
+RUN yarn install
 
 RUN apk del git
-
-# Link in the global install because `require()` only looks for ./node_modules
-# WARNING: This is overwritten by volume-mount at runtime!
-#          See docker-compose.yml for instructions
-RUN ln -sf $NPM_PACKAGES/node_modules node_modules
 
 # Set this to inspect more from the application. Examples:
 #   DEBUG=formio:db (see index.js for more)

--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ Run with Docker Compose
 ------------------
 The fastest way to run this library locally is to use [Docker](https://docker.com).
 
- - [Install Docker](https://docs.docker.com/v17.12/install/)
+ - [Install Docker](https://docs.docker.com/engine/install/)
  - Download and unzip this package to a local directory on your machine.
  - Open up your terminal and navigate to the unzipped folder of this library.
  - Type the following in your terminal
     ```
-    npm install
-    docker-compose up
+    # create persistent storage for your Dockerized MongoDB
+    mkdir mdb-data
+    # create the Formio Docker image and run it along with MongoDB
+    docker-compose up -d
     ```
  - Go to the following URL in your browser.
     ```

--- a/README.md
+++ b/README.md
@@ -25,11 +25,9 @@ The fastest way to run this library locally is to use [Docker](https://docker.co
  - Open up your terminal and navigate to the unzipped folder of this library.
  - Type the following in your terminal
     ```
-    # create persistent storage for your Dockerized MongoDB
-    mkdir mdb-data
-    # create the Formio Docker image and run it along with MongoDB
     docker-compose up -d
     ```
+
  - Go to the following URL in your browser.
     ```
     http://localhost:3001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: mongo
     restart: always
     volumes:
-      - "./mdb-data:/data/db"
+      - mdb-data:/data/db
     environment:
       - MONGO_INITDB_ROOT_USERNAME
       - MONGO_INITDB_ROOT_PASSWORD
@@ -12,7 +12,6 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
-    platform: linux/amd64 # Target architecture    restart: always
     links:
       - mongo
     ports:
@@ -24,3 +23,5 @@ services:
       ROOT_PASSWORD: CHANGEME
     stdin_open: true # -i
     tty: true # -t
+volumes:
+  mdb-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,48 +1,26 @@
-# Allows us to start the stack without touching too much of our local system
-#
-# note: the application initialization will download/unpack/configure files
-#       in the local directory...
-#
-# ##### Usage:
-# *0. Create a broken symlink: `ln -sf "/.npm-packages/node_modules/" node_modules`
-# 1. Start the database: `docker compose up -d mongo`
-# 2. Start the application:  `docker compose run formio`
-# [3]. Stop the database: `docker compose down` (add --volumes to clear data)
-# [4]. Remove lingering docker images: `docker compose down -v --rmi all`
-#
-# *TODO: Step 0 is for the bcrypt binary compiled on alpine, which is required...
-#        but this step feels like an anti-pattern and a better approach should be found
-
-version: '3.7'
+version: "3.8"
 services:
   mongo:
-    image: mongo:4.1
+    image: mongo
     restart: always
     volumes:
-      - mdb-data:/data/db
+      - "./mdb-data:/data/db"
     environment:
       - MONGO_INITDB_ROOT_USERNAME
       - MONGO_INITDB_ROOT_PASSWORD
-
   formio:
-    build: ./
-    # The app will restart until Mongo is listening
-    restart: always
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    platform: linux/amd64 # Target architecture    restart: always
     links:
       - mongo
     ports:
       - "3001:3001"
-    # The application wants to download things to the local directory
-    # TODO: really wish I could mount this as read-only
-    volumes:
-      - ./:/app:rw
     environment:
       DEBUG: formio:*
       NODE_CONFIG: '{"mongo": "mongodb://mongo:27017/formio"}'
       ROOT_EMAIL: admin@example.com
       ROOT_PASSWORD: CHANGEME
-    stdin_open: true  # -i
-    tty: true         # -t
-
-volumes:
-  mdb-data:
+    stdin_open: true # -i
+    tty: true # -t

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
+    restart: always
     links:
       - mongo
     ports:


### PR DESCRIPTION
## Link to Jira Ticket

n/a

## Description

Previously our open source Dockerfile simply mounted the source directory as a read/write volume. As we've introduced additional dependencies that require a build step and result in arch-specific binaries, this approach is not sustainable. This PR modernizes the Dockerfile to build an image that is independent of the host machine.

## Dependencies

n/a

## How has this PR been tested?

locally

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
