### PR TITLE
Fixing tests with latest core

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "schema": "3.1.4",
   "templateVersion": "2.0.0",
   "dependencies": {
-    "@formio/core": "^2.0.0-rc.10",
+    "@formio/core": "^2.0.0-rc.12",
     "@formio/node-fetch-http-proxy": "^1.1.0",
-    "@formio/vm": "^0.0.6",
+    "@formio/vm": "^0.0.7-rc.3",
     "JSONStream": "^1.3.5",
     "adm-zip": "^0.5.9",
     "async": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formio",
-  "version": "4.0.0-dev.2",
+  "version": "4.0.0-dev.tt.1",
   "description": "The formio server application.",
   "license": "OSL-3.0",
   "main": "index.js",
@@ -17,7 +17,7 @@
   "schema": "3.1.4",
   "templateVersion": "2.0.0",
   "dependencies": {
-    "@formio/core": "^2.0.0-rc.12",
+    "@formio/core": "^2.0.0-dev.tt.1",
     "@formio/node-fetch-http-proxy": "^1.1.0",
     "@formio/vm": "^0.0.7-rc.3",
     "JSONStream": "^1.3.5",

--- a/test/submission.js
+++ b/test/submission.js
@@ -1617,8 +1617,7 @@ module.exports = function(app, template, hook) {
                   setting: true,
                   validator: 'required',
                   label: 'Required Field',
-                  path: 'requiredField',
-                  value: ''
+                  path: 'requiredField'
                 },
                 message: 'Required Field is required',
                 level: 'error',
@@ -1987,8 +1986,7 @@ module.exports = function(app, template, hook) {
                   label: 'Required Field',
                   setting: true,
                   validator: 'required',
-                  path: 'requiredField',
-                  value: ''
+                  path: 'requiredField'
                 },
                 message: 'Required Field is required',
                 level: 'error',
@@ -2816,13 +2814,11 @@ module.exports = function(app, template, hook) {
             var submission = helper.getLastSubmission();
             assert.equal(helper.lastResponse.statusCode, 400);
             assert.equal(helper.lastResponse.body.name, 'ValidationError');
-            assert.equal(helper.lastResponse.body.details.length, 3);
-            assert.equal(helper.lastResponse.body.details[0].message, 'Text Field must be a non-empty array');
+            assert.equal(helper.lastResponse.body.details.length, 2);
+            assert.equal(helper.lastResponse.body.details[0].message, 'Text Field must be an array');
             assert.equal(helper.lastResponse.body.details[1].message, 'Text Field is required');
-            assert.equal(helper.lastResponse.body.details[2].message, 'Text Field must be an array');
             assert.deepEqual(helper.lastResponse.body.details[0].path, ['textField']);
             assert.deepEqual(helper.lastResponse.body.details[1].path, ['textField']);
-            assert.deepEqual(helper.lastResponse.body.details[2].path, ['textField']);
             done();
           });
       });
@@ -3774,8 +3770,7 @@ module.exports = function(app, template, hook) {
                   label: 'Test',
                   setting: true,
                   path: 'test',
-                  validator: 'required',
-                  value: ''
+                  validator: 'required'
                 },
                 level: 'error',
                 message: 'Test is required',


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7885

## Description

**What changed?**

With some of our previous changes made to the @formio/core validation system, we ended up having to fix tests by ADDING the "value: ''" property to the response of the validation errors messages. It was determined at that time that these were fairly benign and would not affect customers. With our latest round of fixes to core, however, it seemed to have resolved the issue of introducing value properties to the validation responses, so this PR actually reverts the tests to how they are evaluated in 8.x server.

## Dependencies

[*This PR depends on the following PRs from other Form.io modules: ...*](https://github.com/formio/core/pull/40)

## How has this PR been tested?

There are numerous tests in this server that test the changes made to core.

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
