### PR TITLE
FIO 7671: nested paths cosmosdb feature test

### DIFF
--- a/src/db/index.js
+++ b/src/db/index.js
@@ -301,7 +301,7 @@ module.exports = function(formio) {
     (async () => {
       config.mongoFeatures = formio.mongoFeatures = {
         collation: true,
-        compoundNestedPaths: true,
+        compoundIndexWithNestedPath: true,
       };
       const featuresTest = db.collection('formio-features-test');
       // Test for collation support
@@ -321,7 +321,7 @@ module.exports = function(formio) {
       }
       catch (err) {
         formio.util.log('Compound indexes that contain nested paths are not supported.');
-        config.mongoFeatures.compoundNestedPaths = formio.mongoFeatures.compoundNestedPaths = false;
+        config.mongoFeatures.compoundIndexWithNestedPath = formio.mongoFeatures.compoundIndexWithNestedPath = false;
       }
       await featuresTest.drop();
       next();

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -300,18 +300,30 @@ module.exports = function(formio) {
     formio.util.log('Determine MongoDB compatibility.');
     (async () => {
       config.mongoFeatures = formio.mongoFeatures = {
-        collation: true
+        collation: true,
+        compoundNestedPaths: true,
       };
+      const featuresTest = db.collection('formio-features-test');
+      // Test for collation support
       try {
-        const collationTest = db.collection('formio-collation-test');
-        await collationTest.createIndex({test: 1}, {collation: {locale: 'en_US', strength: 1}});
-        await collationTest.drop();
+        await featuresTest.createIndex({test: 1}, {collation: {locale: 'en_US', strength: 1}});
         formio.util.log('Collation indexes are supported.');
       }
       catch (err) {
         formio.util.log('Collation indexes are not supported.');
         config.mongoFeatures.collation = formio.mongoFeatures.collation = false;
       }
+
+      // Test for support for compound indexes that contain nested paths
+      try {
+        await featuresTest.createIndex({test: 1, 'nested.test': 1});
+        formio.util.log('Compound indexes that contain nested paths are supported.');
+      }
+      catch (err) {
+        formio.util.log('Compound indexes that contain nested paths are not supported.');
+        config.mongoFeatures.compoundNestedPaths = formio.mongoFeatures.compoundNestedPaths = false;
+      }
+      await featuresTest.drop();
       next();
     })();
   };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7671

## Description

An enterprise customer was running into an error - "Unique and compound indexes do not support nested paths" - when creating submissions collections versus their CosmosDB installation. It seems that in certain CosmosDB deployments creating a compound index with a nested path (e.g. `createIndex({col1: 1, 'data.col1': 1})`) will cause an error to bubble to the client, whereas in other deployments (ours in particular) the operation will fail silently and the index will simply not be created. 

Although I'm still not sure of where the difference in these deployments lies - perhaps Microsoft does A/B feature testing on a subset of users? perhaps there's a deep beta-feature setting that is enabled by default on some deployments and not on others? - this PR adds a feature check at startup to ascertain whether creation of indexes of this type will throw an error. If it does, it will not attempt to create compound indexes with nested paths as part of the schema models.

## Dependencies

n/a

## How has this PR been tested?

Tough to test because success or failure depends on your database vendor. That said, I tested this manually versus the problematic CosmosDB installation, and creating submission collections now works as expected.

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
