### PR TITLE
FIO 8047: add dereference for datatable components

### DIFF
--- a/src/middleware/submissionHandler.js
+++ b/src/middleware/submissionHandler.js
@@ -229,10 +229,11 @@ module.exports = (router, resourceName, resourceId) => {
       hook.alter('validateSubmissionForm', req.currentForm, req.body, async form => { // eslint-disable-line max-statements
         // Get the submission model.
         const submissionModel = req.submissionModel || router.formio.resources.submission.model;
+        const formModel = router.formio.resources.form.model;
         const tokenModel = router.formio.mongoose.models.token;
 
         // Validate the request.
-        const validator = new Validator(req, submissionModel, tokenModel, hook);
+        const validator = new Validator(req, submissionModel, formModel, tokenModel, hook);
         await validator.validate(req.body, (err, data, visibleComponents) => {
           if (req.noValidate) {
             return done();

--- a/src/resources/Validator.js
+++ b/src/resources/Validator.js
@@ -264,8 +264,8 @@ class Validator {
       }
     }
     catch (err) {
-      debug.error(err);
-      return next(err);
+      debug.error(err.message || err);
+      return next(err.message || err);
     }
 
     // If there are errors, return the errors.

--- a/test/submission.js
+++ b/test/submission.js
@@ -3403,6 +3403,180 @@ module.exports = function(app, template, hook) {
       });
     });
 
+    describe('Data table validation', () => {
+      before((done) => {
+        // Create a resource to keep records.
+        helper
+          .form('fruits', [
+            {
+              "input": true,
+              "tableView": true,
+              "inputType": "text",
+              "inputMask": "",
+              "label": "Name",
+              "key": "name",
+              "placeholder": "",
+              "prefix": "",
+              "suffix": "",
+              "multiple": false,
+              "defaultValue": "",
+              "protected": false,
+              "unique": false,
+              "persistent": true,
+              "validate": {
+                "required": false,
+                "minLength": "",
+                "maxLength": "",
+                "pattern": "",
+                "custom": "",
+                "customPrivate": false
+              },
+              "conditional": {
+                "show": null,
+                "when": null,
+                "eq": ""
+              },
+              "type": "textfield"
+            },
+          ])
+          .submission('fruits', {name: 'Apple'})
+          .submission('fruits', {name: 'Pear'})
+          .submission('fruits', {name: 'Banana'})
+          .submission('fruits', {name: 'Orange'})
+          .execute(function(err) {
+            if (err) {
+              return done(err);
+            }
+
+            let apiUrl = 'http://localhost:' + template.config.port;
+            apiUrl += hook.alter('url', '/form/' + helper.template.forms['fruits']._id + '/submission', helper.template);
+
+            helper
+              .form('fruitTable', [
+                {
+                  label: 'Pick Some Fruits',
+                  sortable: true,
+                  filterable: true,
+                  inlineEditing: false,
+                  clipCells: false,
+                  itemsPerPage: 10,
+                  showAddBtn: true,
+                  showEditBtn: true,
+                  showDeleteBtn: true,
+                  showDeleteAllBtn: false,
+                  tableView: false,
+                  isSubmitData: false,
+                  fetch: {
+                    enableFetch: true,
+                    headers: [{}],
+                    components: [
+                      {
+                        path: 'name',
+                        key: 'name',
+                      },
+                    ],
+                    dataSrc: 'resource',
+                    sort: {
+                      defaultQuery: '',
+                    },
+                    resource: helper.template.forms['fruits']._id,
+                  },
+                  key: 'dataTable',
+                  type: 'datatable',
+                  allowCaching: true,
+                  input: true,
+                  submitSelectedRows: true,
+                  components: [],
+                }
+              ])
+              .execute((err) => {
+                if (err) {
+                  return done(err);
+                }
+                done();
+              });
+          });
+      });
+
+      it('Should save the submission of the selected values', (done) => {
+        helper.submission('fruitTable', {dataTable: [{name: 'Apple'}, {name: 'Pear'}]}).execute((err) => {
+          if (err) {
+            return done(err);
+          }
+
+          var submission = helper.getLastSubmission();
+          assert.deepEqual({dataTable: [{name: 'Apple'}, {name: 'Pear'}]}, submission.data);
+          done();
+        });
+      });
+
+      it('Should modify the target resource and the form by adding a required field', (done) => {
+        const target = helper.template.forms['fruits'];
+        target.components.push({
+          "input": true,
+          "tableView": true,
+          "inputType": "text",
+          "inputMask": "",
+          "label": "Color",
+          "key": "color",
+          "placeholder": "",
+          "prefix": "",
+          "suffix": "",
+          "multiple": false,
+          "defaultValue": "",
+          "protected": false,
+          "unique": false,
+          "persistent": true,
+          "validate": {
+            "required": true,
+            "minLength": "",
+            "maxLength": "",
+            "pattern": "",
+            "custom": "",
+            "customPrivate": false
+          },
+          "conditional": {
+            "show": null,
+            "when": null,
+            "eq": ""
+          },
+          "type": "textfield"
+        });
+        helper
+          .updateForm(target, (err) => {
+            if (err) {
+              return done(err);
+            }
+            const form = helper.template.forms['fruitTable'];
+            assert(form.components[0]);
+            assert(form.components[0].fetch);
+            assert(form.components[0].fetch.components);
+            form.components[0].fetch.components.push({path: 'color', key: 'color'});
+            helper.updateForm(form, (err) => {
+              if (err) {
+                return done(err);
+              }
+              done();
+            });
+          });
+      });
+
+      it('Should throw an error when the new field is not provided', (done) => {
+        helper.submission('fruitTable', {dataTable: [{name: 'Apple'}, {name: 'Orange'}]}).expect(400).execute((err) => {
+          if (err) {
+            return done(err);
+          }
+          assert.equal(helper.lastResponse.statusCode, 400);
+          assert.equal(helper.lastResponse.body.name, 'ValidationError');
+          assert.equal(helper.lastResponse.body.details.length, 2);
+          assert.equal(helper.lastResponse.body.details[0].message, 'Color is required');
+          assert.deepEqual(helper.lastResponse.body.details[0].path, ['dataTable', 0, 'color']);
+          done();
+        });
+      });
+    });
+
+
     describe('Advanced Conditions', () => {
       it('Requires a conditionally required field from advanced conditions', function(done) {
         var components = [


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8047

## Description

Because Data Table components have an array data model, @formio/core's `filter` process will skip over their submission data with the expectation that their constituent components will be iterated over by eachComponentData. However, Data Table components that use the "Reference" data source populate their components at runtime, which means that the form component that the server has access to has only an empty array. This PR adds a method to the `Validator` class that is injected into the `dereference` processor to dereference the target Resource by accessing the database directly.

This can and should eventually be expanded to cover all dereferencing use cases such as save-as-reference submission objects or other components that lazily load their constituent components from a resource, which is currently a "property action."

## Dependencies

[@formio/core#58](https://github.com/formio/core/pull/58)

## How has this PR been tested?

Added automated integration tests

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
