### PR TITLE
FIO-8169: add resolve dep to mirror enterprise server

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "progress": "^2.0.3",
     "prompt": "^1.3.0",
     "q": "^1.5.0",
+    "resolve": "^1.22.8",
     "resourcejs": "^2.5.0",
     "semver": "^7.3.8",
     "superagent-retry": "^0.6.0",

--- a/src/util/staticVmDependencies.js
+++ b/src/util/staticVmDependencies.js
@@ -1,11 +1,12 @@
 'use strict';
 const fs = require('fs');
+const resolve = require('resolve/sync');
 
-const lodashCode = fs.readFileSync(require.resolve('lodash/lodash.min.js'), 'utf8');
-const momentCode = fs.readFileSync(require.resolve('moment/min/moment.min.js'), 'utf8');
-const formioCoreCode = fs.readFileSync(require.resolve('@formio/core/dist/formio.core.min.js'), 'utf8');
-const fastJsonPatchCode = fs.readFileSync(require.resolve('fast-json-patch/dist/fast-json-patch.min.js'), 'utf8');
-const nunjucksCode = fs.readFileSync(require.resolve('nunjucks/browser/nunjucks.min.js'), 'utf8');
+const lodashCode = fs.readFileSync(resolve('lodash/lodash.min.js'), 'utf8');
+const momentCode = fs.readFileSync(resolve('moment/min/moment.min.js'), 'utf8');
+const formioCoreCode = fs.readFileSync(resolve('@formio/core/dist/formio.core.min.js'), 'utf8');
+const fastJsonPatchCode = fs.readFileSync(resolve('fast-json-patch/dist/fast-json-patch.min.js'), 'utf8');
+const nunjucksCode = fs.readFileSync(resolve('nunjucks/browser/nunjucks.min.js'), 'utf8');
 
 module.exports = {
     lodash: lodashCode,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2555,6 +2555,13 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
+is-core-module@^2.13.0:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.1.tgz#ad0d7532c6fea9da1ebdc82742d74525c6273384"
+  integrity sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==
+  dependencies:
+    hasown "^2.0.0"
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -3297,6 +3304,11 @@ path-key@^3.1.0:
   resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
+path-parse@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
@@ -3538,6 +3550,15 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+resolve@^1.22.8:
+  version "1.22.8"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
+  integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
+  dependencies:
+    is-core-module "^2.13.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 resourcejs@^2.5.0:
   version "2.6.0"
@@ -3885,6 +3906,11 @@ supports-color@^7.1.0:
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
+
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 tar-fs@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8169

## Description

Use the resolve dependency (68MM weekly downloads) to resolve filepaths rather than require. This change isn't strictly necessary because this code isn't bundled by webpack as the Enterprise Server code is (see [formio-server#1468](https://github.com/formio/formio-server/pull/1468)) but I figure it'd be nice to keep it consistent.

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
