### PR TITLE
 FIO-8152 & FIO-8137: Check if Import Resource Exists in New Project for Select Component with Resource & De-ref default values on select with resource

### DIFF
--- a/src/templates/export.js
+++ b/src/templates/export.js
@@ -175,7 +175,14 @@ module.exports = (router) => {
             if (component && component.project) {
               component.project = 'project';
             }
-            if (component && component.defaultValue) {
+            // During export if select component
+            // data type resource de-ref defaultValue
+            if (
+              component
+              && component.type === 'select'
+              && component.dataSrc === 'resource'
+              && component.defaultValue
+            ) {
               component.defaultValue = undefined;
             }
 

--- a/src/templates/export.js
+++ b/src/templates/export.js
@@ -175,6 +175,9 @@ module.exports = (router) => {
             if (component && component.project) {
               component.project = 'project';
             }
+            if (component && component.defaultValue) {
+              component.defaultValue = undefined;
+            }
 
             if (component.hasOwnProperty('form') && component.revision) {
               _map.revisions.revisionsData.push(component);

--- a/src/templates/import.js
+++ b/src/templates/import.js
@@ -203,18 +203,11 @@ module.exports = (router) => {
    * @returns {Promise<Object|null>} A promise that resolves with the found document or null if no document is found.
    */
   const checkForExistingResource = (resource, projectId) => {
-    return new Promise((resolve, reject) => {
-        formio.resources.form.model.findOne({
-            name: resource,
-            project: projectId,
-            deleted: {$eq: null}
-        }).exec((err, doc) => {
-            if (err) {
-                return reject(err);
-            }
-            resolve(doc);
-        });
-    });
+    return formio.resources.form.model.findOne({
+      name: resource,
+      project: projectId,
+      deleted: {$eq: null}
+    }).exec();
   };
 
   /**
@@ -338,7 +331,7 @@ module.exports = (router) => {
       }
     });
 
-    return changed;
+     return changed;
   };
 
   const fallbackNestedForms = (nestedForms, template, cb) => {

--- a/src/templates/import.js
+++ b/src/templates/import.js
@@ -206,7 +206,8 @@ module.exports = (router) => {
     return new Promise((resolve, reject) => {
         formio.resources.form.model.findOne({
             name: resource,
-            project: projectId
+            project: projectId,
+            deleted: {$eq: null}
         }).exec((err, doc) => {
             if (err) {
                 return reject(err);
@@ -256,18 +257,20 @@ module.exports = (router) => {
     }
 
     // Check if an existing resource exists in the new project.
-    (async () => {
-      try {
-        const resource = await checkForExistingResource(entity.resource, template._id);
-        if (resource) {
-          entity.resource = resource._id;
-          changes = true;
+    if (!changes && !formio.mongoose.Types.ObjectId.isValid(entity.resource)) {
+      (async () => {
+        try {
+          const resource = await checkForExistingResource(entity.resource, template._id);
+          if (resource) {
+            entity.resource = resource._id;
+            changes = true;
+          }
         }
-      }
-      catch (err) {
-        debug.install(err);
-      }
-    })();
+        catch (err) {
+          debug.install(err);
+        }
+      })();
+    }
 
     return changes;
   };

--- a/src/templates/import.js
+++ b/src/templates/import.js
@@ -309,6 +309,19 @@ module.exports = (router) => {
         changed = true;
       }
 
+      // During import if select component
+      // data type resource de-ref defaultValue
+      if (
+        component
+        && component.type === 'select'
+        && component.dataSrc === 'resource'
+        && component.defaultValue
+      ) {
+        component.defaultValue = undefined;
+        hook.alter(`importComponent`, template, component);
+        changed = true;
+      }
+
       // Update resource machineNames for dataTable components with the resource data type.
       if (
         (component.type === 'datatable') &&

--- a/test/fixtures/templates/projectWithExistingResource.json
+++ b/test/fixtures/templates/projectWithExistingResource.json
@@ -1,0 +1,64 @@
+{
+    "title": "Project with Existing Resource",
+    "version": "2.0.0",
+    "name": "projectWithExistingResource",
+    "roles": {},
+    "forms": {},
+    "actions": {
+      "customer:save": {
+        "title": "Save Submission",
+        "name": "save",
+        "form": "customer",
+        "priority": 10,
+        "method": [
+          "create",
+          "update"
+        ],
+        "handler": [
+          "before"
+        ]
+      }
+    },
+    "resources": {
+      "customer": {
+        "title": "Customer",
+        "type": "resource",
+        "name": "customer",
+        "path": "customer",
+        "display": "form",
+        "tags": [],
+        "settings": {},
+        "components": [
+          {
+            "label": "Name",
+            "applyMaskOn": "change",
+            "tableView": true,
+            "key": "name",
+            "type": "textfield",
+            "input": true
+          },
+          {
+            "label": "Email",
+            "applyMaskOn": "change",
+            "tableView": true,
+            "key": "email",
+            "type": "email",
+            "input": true
+          },
+          {
+            "type": "button",
+            "label": "Submit",
+            "key": "submit",
+            "disableOnInvalid": true,
+            "input": true,
+            "tableView": false
+          }
+        ],
+        "properties": {},
+        "controller": "",
+        "submissionRevisions": ""
+      }
+    },
+    "revisions": {},
+    "excludeAccess": true
+  }

--- a/test/fixtures/templates/selectWithResourceDataSrcAndDefaultValueNoResourcesExport.json
+++ b/test/fixtures/templates/selectWithResourceDataSrcAndDefaultValueNoResourcesExport.json
@@ -1,0 +1,83 @@
+{
+  "title": "Select with Resource dataSrc and defaultValue No Resources Export",
+  "version": "2.0.0",
+  "name": "selectWithResourceDataSrcAndDefaultValueNoResourcesExport",
+  "roles": {},
+  "forms": {
+      "selectWithResourceDataSrcAndDefaultValueNoResourcesExport": {
+          "title": "Select Form with Resource Ref and Default Value No Resources Export",
+          "type": "form",
+          "name": "selectWithResourceDataSrcAndDefaultValueNoResourcesExport",
+          "path": "selectwithresourcedatasrcanddefaultvaluenoresourcesexport",
+          "pdfComponents": [],
+          "tags": [],
+          "access": [
+            {
+              "type": "read_all",
+              "roles": [
+                "anonymous"
+              ]
+            }
+          ],
+          "submissionAccess": [
+            {
+              "type": "create_own",
+              "roles": [
+                "anonymous"
+              ]
+            }
+          ],
+          "components": [
+            {
+              "label": "Customer Name",
+              "widget": "choicesjs",
+              "tableView": true,
+              "dataSrc": "resource",
+              "data": {
+                  "resource": "customer"
+              },
+              "template": "\u003Cspan\u003E{{ item.data.name }}\u003C/span\u003E",
+              "key": "customerName",
+              "type": "select",
+              "noRefreshOnScroll": false,
+              "addResource": false,
+              "reference": true,
+              "input": true,
+              "defaultValue": {
+                "_id": "66158925427fb151bc0e9853",
+                "form": "6615890e427fb151bc0e974d",
+                "owner": "661588be427fb151bc0e95a0",
+                "roles": [],
+                "access": [],
+                "metadata": {
+                  "timezone": "America/Chicago",
+                  "offset": -300,
+                  "origin": "http://localhost:3000",
+                  "referrer": "",
+                  "browserName": "Netscape"
+                },
+                "data": {
+                  "name": "Jim"
+                },
+                "_fvid": 0,
+                "project": "661588de427fb151bc0e9663",
+                "state": "submitted",
+                "externalIds": [],
+                "created": "2024-04-09T18:29:57.822Z",
+                "modified": "2024-04-09T18:29:57.823Z"
+              }
+            },
+            {
+              "type": "button",
+              "label": "Submit",
+              "key": "submit",
+              "disableOnInvalid": true,
+              "input": true,
+              "tableView": false
+            }
+          ]
+        }
+  },
+  "actions": {},
+  "resources": {}
+}

--- a/test/templates.js
+++ b/test/templates.js
@@ -3809,12 +3809,13 @@ module.exports = (app, template, hook) => {
       const existingResourceTemplate = 'projectWithExistingResource'
       let existingResourceTemplateSchema = require(`./fixtures/templates/${existingResourceTemplate}.json`);
       let _existingTemplate = _.cloneDeep(existingResourceTemplateSchema);
-      let templateDataStartValue = _template.forms[selectFormName].components[0].data.resource;
 
       const selectFormName = 'selectWithResourceDataSrcAndDefaultValueNoResourcesExport'
       let testTemplate = require(`./fixtures/templates/${selectFormName}.json`);
       let _template = _.cloneDeep(testTemplate);
       let project;
+
+      let templateDataStartValue = _template.forms[selectFormName].components[0].data.resource;
 
       describe('Import', function() {
         it('Import existing resource template', function(done) {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8152 & https://formio.atlassian.net/browse/FIO-8137

## Description

**What changed?**

Previously if import and export the template would include select dropdowns of `dataSrc == resource` that included the `defaultValue` in the export. This will now de-ref the `defaultValue` during export and import to this information being varying in the target stage.

Previously if export template did not include a resource it would NOT check the target project to see if that resource already exists. Now, even if there's no resource included in the export template it will check the target project to see if there's a matching resource for select dropdowns of `dataSrc === resource`.

**Why have you chosen this solution?**

Accomplishes the acceptance criteria requested. 
```
- Add default values to the list of keys to dereference when importing and exporting.
- References to resource should properly rereference when a form is imported to a project where the resource already exists, even if the resource is not part of the imported json.
```

## Dependencies

n/a

## How has this PR been tested?

Locally and tests were created
https://github.com/formio/formio/actions/runs/8787678879/job/24113405391#step:8:542
![image](https://github.com/formio/formio/assets/112976114/de93d38a-b7b0-4ae9-8f13-1fadfc1d9472)
![image](https://github.com/formio/formio/assets/112976114/53269c7c-5034-4a0e-a2b1-07b7a932bad6)

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
