### PR TITLE
FIO-8171: add configurable VM2 timeout to 3.4.x

### DIFF
--- a/src/actions/SaveSubmission.js
+++ b/src/actions/SaveSubmission.js
@@ -205,7 +205,7 @@ module.exports = function(router) {
         if (this.settings.transform) {
           try {
             let vm = new VM({
-              timeout: 500,
+              timeout: router.formio.config.vmTimeout,
               sandbox: {
                 submission: (res.resource && res.resource.item) ? res.resource.item : req.body,
                 data: submission.data,

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -244,7 +244,7 @@ module.exports = (router) => {
           }, req);
 
           let vm = new VM({
-            timeout: 500,
+            timeout: router.formio.config.vmTimeout,
             sandbox: {
               execute: params.execute,
               query: params.query,

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -45,7 +45,9 @@ _.each(Formio.Displays.displays, (display) => {
 });
 
 const vm = new VM({
-  timeout: 250,
+  // use the environment variable directly here so as to avoid refactoring utils everywhere it is called to access the config object
+  // (this is a backport after all)
+  timeout: process.env.FORMIO_VM_TIMEOUT || 5000,
   sandbox: {
     result: null,
   },

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -47,7 +47,7 @@ _.each(Formio.Displays.displays, (display) => {
 const vm = new VM({
   // use the environment variable directly here so as to avoid refactoring utils everywhere it is called to access the config object
   // (this is a backport after all)
-  timeout: process.env.FORMIO_VM_TIMEOUT || 5000,
+  timeout: Number(process.env.FORMIO_VM_TIMEOUT) || 500,
   sandbox: {
     result: null,
   },
@@ -64,7 +64,9 @@ Formio.Utils.Evaluator.evaluator = function(func, args) {
 
       result = vm.run(`result = (function({${_.keys(args).join(',')}}) {${func}})(args);`);
     }
-    catch (err) {}
+    catch (err) {
+      console.error(err);
+    }
     /* eslint-enable no-empty */
     return result;
   };

--- a/test/config.json
+++ b/test/config.json
@@ -12,5 +12,6 @@
     "secret": "insert-some-secret-here",
     "expireTime": 240
   },
-  "settings": {}
+  "settings": {},
+  "vmTimeout": 500
 }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8171

## Description

Adds a configurable VM2 timeout

## Dependencies

* [formio-workers#55](https://github.com/formio/formio-workers/pull/55)

## How has this PR been tested?

I added automated tests to formio-server

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
