### PR TITLE
FIO-8152: Check if Import Resource Exists in New Project for Select Component with Resource 

### DIFF
--- a/test/fixtures/templates/selectWithResourceDataSrcAndDefaultValueNoResourcesExport.json
+++ b/test/fixtures/templates/selectWithResourceDataSrcAndDefaultValueNoResourcesExport.json
@@ -1,11 +1,11 @@
 {
-  "title": "Select with Resource dataSrc and defaultValue No Resources Export",
+  "title": "Select w/ Resource dataSrc & defaultValue No Resources Export",
   "version": "2.0.0",
   "name": "selectWithResourceDataSrcAndDefaultValueNoResourcesExport",
   "roles": {},
   "forms": {
       "selectWithResourceDataSrcAndDefaultValueNoResourcesExport": {
-          "title": "Select Form with Resource Ref and Default Value No Resources Export",
+          "title": "Select w/ Resource dataSrc & defaultValue No Resources Export",
           "type": "form",
           "name": "selectWithResourceDataSrcAndDefaultValueNoResourcesExport",
           "path": "selectwithresourcedatasrcanddefaultvaluenoresourcesexport",

--- a/test/templates.js
+++ b/test/templates.js
@@ -3815,6 +3815,10 @@ module.exports = (app, template, hook) => {
       let _template = _.cloneDeep(testTemplate);
       let project;
 
+      // Modify the template name before importing
+      // If not will not be able to import into same project.
+      _template.name = existingResourceTemplate;
+
       let templateDataStartValue = _template.forms[selectFormName].components[0].data.resource;
 
       describe('Import', function() {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8137 & https://formio.atlassian.net/browse/FIO-8152

## Description

**What changed?**

### This test was failing in `formio-server`
https://app.circleci.com/pipelines/github/formio/formio-server/5909/workflows/b4f34671-52df-49ae-ac45-69804f6355c2/jobs/27302

The issue was that the project templates utilized had different names. In `formio` we do not have the concept of project seperation so they'd get imported as the same template wihtout issue. When this test is done in formio-server they need to match up so that when imported they are seen as the same project template.

https://github.com/formio/formio/blob/0781c7f528d42b7f5cd81ceb56fef8ba18d86798/test/templates.js#L3809-L3824

**Why have you chosen this solution?**

This will allow tests to pass on `formio` and `formio-server`

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?
Passes pipeline tests for `formio`
https://github.com/formio/formio/actions/runs/9115842533/job/25063108692#step:8:549

Passes `formio-server` tests locally
![image](https://github.com/formio/formio/assets/112976114/0908edcd-cab6-42c8-a893-7f8a47e3a33d)

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
