### PR TITLE
FIO-7299: Fix email action with the 'before' handler issues

### DIFF
--- a/src/actions/EmailAction.js
+++ b/src/actions/EmailAction.js
@@ -1,5 +1,6 @@
 'use strict';
 const fetch = require('@formio/node-fetch-http-proxy');
+const _ = require('lodash');
 
 const LOG_EVENT = 'Email Action';
 
@@ -254,11 +255,12 @@ module.exports = (router) => {
                     .catch(() => this.settings.message);
               })
               .then((template) => {
-                this.settings.message = template;
+                const settingsCloned = _.cloneDeep(this.settings);
+                settingsCloned.message = template;
                 setActionItemMessage('Sending message', this.message);
 
                 req.params = reqParams;
-                emailer.send(req, res, this.settings, params, (err) => {
+                emailer.send(req, res, settingsCloned, params, (err) => {
                   if (err) {
                     setActionItemMessage('Error sending message', {
                       message: err.message || err


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7299

## Description

**What changed?**

Previously, if email action was configured with both 'before' and 'after' handlers, the message sent for the 'after' would be broken. This PR makes a fix for this issue.

**Why have you chosen this solution?**

Problem was with settings object reference kept the same, so I've made a clone of it for every new email being sent.

## Dependencies

None

## How has this PR been tested?

I've added a test for the failing scenario

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
