### PR TITLE
FIO-8428: Fixes save submission action data transformation

### DIFF
--- a/src/middleware/submissionHandler.js
+++ b/src/middleware/submissionHandler.js
@@ -217,7 +217,7 @@ module.exports = (router, resourceName, resourceId) => {
       let isSubform = formId && formId.toString() !== req.currentForm._id.toString();
       isSubform = !isSubform && req.mainForm ? req.mainForm.toString() !== req.currentForm._id.toString() : isSubform;
       req.submission = req.submission || {data: {}};
-      if (!_.isEmpty(req.submission.data) && !isSubform) {
+      if (!_.isEmpty(req.submission.data) && !isSubform && !req.isTransformedData) {
         req.body.data = _.assign(req.body.data, req.submission.data);
       }
 

--- a/test/fixtures/forms/testMappingDataForm.js
+++ b/test/fixtures/forms/testMappingDataForm.js
@@ -1,0 +1,42 @@
+module.exports = {
+  access: [],
+  submissionAccess: [],
+  components: [
+    {
+      type: 'textfield',
+      validate: {
+        custom: '',
+        pattern: '',
+        maxLength: '',
+        minLength: '',
+        required: false,
+      },
+      defaultValue: '',
+      multiple: false,
+      suffix: '',
+      prefix: '',
+      key: 'textField1',
+      inputMask: '',
+      inputType: 'text',
+      input: true,
+    },
+    {
+      type: 'textfield',
+      validate: {
+        custom: '',
+        pattern: '',
+        maxLength: '',
+        minLength: '',
+        required: false,
+      },
+      defaultValue: '',
+      multiple: false,
+      suffix: '',
+      prefix: '',
+      key: 'textField2',
+      inputMask: '',
+      inputType: 'text',
+      input: true,
+    },
+  ],
+};


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8428

## Description

**What changed?**

Submission data transformation was working not right because of misconfiguration of @formio/vm evaluator, this PR adjusts the options so that data is getting transformed correctly.

**Why have you chosen this solution?**

*Use this section to justify your choices*

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

I've added automated tests that verify data is submitted to configured resource and it's transformed as defined in save submission action settings.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
