### PR TITLE
Update Dockerfile to use 'portal' instead of 'client' following directory rename

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM node:lts-alpine3.19
 # Copy source dependencies
 COPY src/ /app/src/
 COPY config/ /app/config
-COPY client/ /app/client/
+COPY portal/ /app/portal/
 COPY *.js /app/
 COPY *.txt /app/
 COPY package.json /app/


### PR DESCRIPTION
## Link to Jira Ticket
None

## Description
**What changed?**
Updated the Dockerfile to reference the `portal` directory instead of `client`. Specifically, replaced `COPY client/ /app/client/` with `COPY portal/ /app/portal/`.

**Why have you chosen this solution?**
In a recent project update, the `client` directory was renamed to `portal`, but the Dockerfile wasn't updated accordingly. This change resolves the Docker build error and aligns with the current project structure.

## Breaking Changes / Backwards Compatibility
While this change itself doesn't break backwards compatibility, Docker builds may fail for older versions of the codebase.

## Dependencies
None

## How has this PR been tested?
- Executed `docker-compose up -d` command, which completed without errors.
- Confirmed that the application's web interface loads in the browser after running the above command.
- As I'm new to this application, I've verified that the app starts without obvious errors, but I cannot comprehensively confirm all expected functionalities.

## Checklist:
- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above