### PR TITLE
update template import to use eachComponent only when dealing with a …

### DIFF
--- a/src/templates/import.js
+++ b/src/templates/import.js
@@ -1141,7 +1141,7 @@ module.exports = (router) => {
           else {
             template.resources[newItem.name]=newItem;
           }
-          const formComponents = checkTemplate(newItem.components, template);
+          const formComponents = checkForm(newItem.components, template);
           if (formComponents.length !== 0) {
             tryToLoadComponents(formComponents, template, projectId, true);
           }
@@ -1169,9 +1169,9 @@ module.exports = (router) => {
     });
   }
 
-  function checkTemplate(components, template) {
+  function checkForm(components, template) {
      const resultArr = [];
-      util.eachComponent(components, (component)=>{
+      util.eachComponent(components, (component) => {
         if (component.hasOwnProperty('form') &&
         !(template.forms.hasOwnProperty(component.form) ||
         template.resources.hasOwnProperty(component.form))) {
@@ -1179,7 +1179,19 @@ module.exports = (router) => {
         }
       });
     return resultArr;
-}
+  }
+
+  function checkTemplate(forms, template) {
+    const resultArr = [];
+    forms.forEach((form) => {
+       if (form.hasOwnProperty('form') &&
+       !(template.forms.hasOwnProperty(form.form) ||
+       template.resources.hasOwnProperty(form.form))) {
+         resultArr.push(form);
+       }
+     });
+   return resultArr;
+  }
 
   // Implement an import endpoint.
   if (router.post) {
@@ -1222,7 +1234,8 @@ module.exports = (router) => {
   return {
     install,
     template: importTemplate,
-    check: checkTemplate,
+    checkForm,
+    checkTemplate,
     tryToLoadComponents,
     findProjectId
   };


### PR DESCRIPTION
## Link to Jira Ticket

n/a

## Description

Template imports were using a form utility `eachComponent` to iterate over both form components _and_ template forms. Upstream changes in the utility prevent its use for non form component arrays, so we've added a function to simply `forEach` over top-level forms and resources on the template.

## Breaking Changes / Backwards Compatibility

This shouldn't have any effect, although template imports should be thoroughly tested.

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
