### PR TITLE
FIO-8798: fixed isEqual for day component with disabled parts

### DIFF
--- a/src/util/conditionOperators/DateGreaterThan.js
+++ b/src/util/conditionOperators/DateGreaterThan.js
@@ -20,8 +20,22 @@ module.exports = class DateGeaterThan extends ConditionOperator {
     value,
     comparedValue,
   }) {
-    const date = moment(value);
-    const comparedDate = moment(comparedValue);
+    // Additional data processing of the date received from the
+    // Day component with disabled day, month or year elements.
+    // allows using moments for data comparison date with disabled day, month or year
+    const normalizeDate = (dateStr) => {
+      if (typeof dateStr === 'string') {
+      return dateStr
+      .replace(/00\//g, '01/')
+      .replace(/\/0000/g, '/0001');
+      }
+      else {
+        return dateStr;
+      }
+    };
+
+    const date = moment(normalizeDate(value));
+    const comparedDate = moment(normalizeDate(comparedValue));
 
     return {
       date,

--- a/test/actions.js
+++ b/test/actions.js
@@ -3814,6 +3814,75 @@ module.exports = (app, template, hook) => {
               ],
             },
             {
+              'label': 'Day with full date',
+              'hideInputLabels': false,
+              'inputsLabelPosition': 'top',
+              'useLocaleSettings': false,
+              'tableView': false,
+              'fields': {
+                  'day': {
+                      'hide': false
+                  },
+                  'month': {
+                      'hide': false
+                  },
+                  'year': {
+                      'hide': false
+                  }
+              },
+              'validateWhenHidden': false,
+              'key': 'day',
+              'type': 'day',
+              'input': true,
+              'defaultValue': ''
+            },
+            {
+              'label': 'Day with hidden day',
+              'hideInputLabels': false,
+              'inputsLabelPosition': 'top',
+              'useLocaleSettings': false,
+              'tableView': false,
+              'fields': {
+                  'day': {
+                      'hide': true
+                  },
+                  'month': {
+                      'hide': false
+                  },
+                  'year': {
+                      'hide': false
+                  }
+              },
+              'validateWhenHidden': false,
+              'key': 'day1',
+              'type': 'day',
+              'input': true,
+              'defaultValue': ''
+            },
+            {
+              'label': 'Day with hidden year',
+              'hideInputLabels': false,
+              'inputsLabelPosition': 'top',
+              'useLocaleSettings': false,
+              'tableView': false,
+              'fields': {
+                  'day': {
+                      'hide': false
+                  },
+                  'month': {
+                      'hide': false
+                  },
+                  'year': {
+                      'hide': true
+                  }
+              },
+              'validateWhenHidden': false,
+              'key': 'day2',
+              'type': 'day',
+              'input': true,
+              'defaultValue': ''
+            },
+            {
               type: 'button',
               label: 'Submit',
               key: 'submit',
@@ -4601,6 +4670,281 @@ module.exports = (app, template, hook) => {
               helper
                 .submission({
                   dateTime: '',
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test isEqual operator with Day component with full date', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'day',
+              operator: 'isEqual',
+              value: '01/01/2025',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              day: '02/01/2025',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  day: '01/01/2025',
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test isNotEqual operator with Day component with full date', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'day',
+              operator: 'isNotEqual',
+              value: '01/01/2025',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              day: '01/01/2025',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  day: '02/01/2025',
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test isEqual operator with Day component with hidden day', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'day1',
+              operator: 'isEqual',
+              value: '01/00/2025',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              day1: '02/00/2025',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  day1: '01/00/2025',
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test isNotEqual operator with Day component with day hidden', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'day1',
+              operator: 'isNotEqual',
+              value: '01/00/2025',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              day1: '01/00/2025',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  day1: '02/00/2025',
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test isEqual operator with Day component with hidden year', (done) => {
+        action.condition = {
+          conjunction: 'all',
+            conditions: [
+              {
+                component: 'day2',
+                operator: 'isEqual',
+                value: '01/01/0000',
+              },
+            ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              day2: '02/01/0000',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  day2: '01/01/0000',
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test isNotEqual operator with Day component with hidden year', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'day2',
+              operator: 'isNotEqual',
+              value: '01/01/0000',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              day2: '01/01/0000',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  day2: '02/01/0000',
                 })
                 .execute((err) => {
                   if (err) {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8798

## Description

Added additional data processing of the date received from the Day component with disabled day, month or year elements.  Instead of the disabled value equal to 00 or 0000 by default, a placeholder has been added (01 and 0001 respectively), which allows using moments for data comparison data and will not affect the comparison results.

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

auto tests
## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
