### PR TITLE
FIO-8903: fixed an issue where actions can be saved without required fields

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -633,7 +633,6 @@ module.exports = (router) => {
       const actionSettings = {
         type: 'fieldset',
         input: false,
-        tree: true,
         legend: 'Action Settings',
         components: []
       };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8903

## Description

**What changed?**

Originally, the fieldset component is a layout component that does not have its own value. Tree property is applicable only for data components. So, tree property inside fieldset causes the data path to be calculated incorrectly  and, consequently, the validation is skipped for components inside.

## How has this PR been tested?

Manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
