### PR TITLE
FIO-8860-8861-8874: fixed an issue where it is impossible to add value for condition operators for time and phone number

### DIFF
--- a/src/util/conditionOperators/index.js
+++ b/src/util/conditionOperators/index.js
@@ -268,6 +268,7 @@ const getValueComponentsForEachFormComponent = (flattenedComponents) => {
       'disabled',
       'description',
       'tooltip',
+      'inputMask'
     ]);
   });
 


### PR DESCRIPTION
## Link to Jira Ticket (if applicable)

https://formio.atlassian.net/browse/FIO-8860
https://formio.atlassian.net/browse/FIO-8874
https://formio.atlassian.net/browse/FIO-8861

## Description

**What changed?**

Removed input mask from the condition value field as it does not allow to add a partial  value and, consequently, the operators like includes, startsWith and some other are not applicable.

## How has this PR been tested?

Manually


https://github.com/formio/formio.js/pull/5764
https://github.com/formio/premium/pull/323

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
