### PR TITLE
FIO-8849: fixed an issue where isEqual operator doenot work for condition based on selectboxes

### DIFF
--- a/src/util/conditionOperators/IsEqualTo.js
+++ b/src/util/conditionOperators/IsEqualTo.js
@@ -15,18 +15,19 @@ module.exports = class IsEqualTo extends ConditionOperator {
   execute({
     value,
     comparedValue,
+    component
   }) {
+    // special check for select boxes
+    if (component?.type === 'selectboxes') {
+      return _.get(value, comparedValue, false);
+    }
+
     if (value && comparedValue && typeof value !== typeof comparedValue && _.isString(comparedValue)) {
       try {
         comparedValue = JSON.parse(comparedValue);
       }
           // eslint-disable-next-line no-empty
       catch (e) {}
-    }
-
-    //special check for select boxes
-    if (_.isObject(value) && comparedValue && _.isString(comparedValue)) {
-      return value[comparedValue];
     }
 
     return _.isEqual(value, comparedValue);

--- a/test/actions.js
+++ b/test/actions.js
@@ -3746,6 +3746,32 @@ module.exports = (app, template, hook) => {
               inputType: 'checkbox',
             },
             {
+              label: 'Select Boxes Numbers',
+              optionsLabelPosition: 'right',
+              tableView: false,
+              values: [
+                {
+                  label: '1',
+                  value: '1',
+                  shortcut: '',
+                },
+                {
+                  label: '2',
+                  value: '2',
+                  shortcut: '',
+                },
+                {
+                  label: '3',
+                  value: '3',
+                  shortcut: '',
+                },
+              ],
+              key: 'selectBoxesNumber',
+              type: 'selectboxes',
+              input: true,
+              inputType: 'checkbox',
+            },
+            {
               label: 'Radio',
               optionsLabelPosition: 'right',
               inline: false,
@@ -3897,6 +3923,11 @@ module.exports = (app, template, hook) => {
               operator: 'isEqual',
               value: 'a',
             },
+            {
+              component: 'selectBoxesNumber',
+              operator: 'isEqual',
+              value: '2',
+            }
           ],
         };
         helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
@@ -3910,6 +3941,11 @@ module.exports = (app, template, hook) => {
                 a: false,
                 b: true,
                 c: false,
+              },
+              selectBoxesNumber: {
+                1: false,
+                2: false,
+                3: false
               }
             }, helper.owner, [/application\/json/, 200])
             .execute((err) => {
@@ -3926,6 +3962,11 @@ module.exports = (app, template, hook) => {
                     a: true,
                     b: false,
                     c: true,
+                  },
+                  selectBoxesNumber: {
+                    1: false,
+                    2: true,
+                    3: false
                   }
                 })
                 .execute((err) => {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8849

## Description

**What changed?**

Added a specific check for select boxes in isEqual operator

## Dependencies

https://github.com/formio/formio.js/pull/5767

## How has this PR been tested?

Manually + tests

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
