### PR TITLE
FIO-8798: added validation of not full dates

### DIFF
--- a/src/util/conditionOperators/DateGreaterThan.js
+++ b/src/util/conditionOperators/DateGreaterThan.js
@@ -13,15 +13,33 @@ module.exports = class DateGeaterThan extends ConditionOperator {
   }
 
   getValidationFormat(component) {
-    return component.dayFirst ? 'DD-MM-YYYY' : 'MM-DD-YYYY';
+    let validationFormat = component.dayFirst ? 'DD-MM-YYYY' : 'MM-DD-YYYY';
+    if (component.fields?.day?.hide) {
+      validationFormat = validationFormat.replace('DD-', '');
+    }
+    if (component.fields?.month?.hide) {
+      validationFormat = validationFormat.replace('MM-', '');
+    }
+
+    if ( component.fields?.year?.hide ) {
+      validationFormat = validationFormat.replace('-YYYY', '');
+    }
+
+    return validationFormat;
+  }
+
+  setDateFormat(component) {
+    return component.type === 'day' ? this.getValidationFormat(component) : '';
   }
 
   getFormattedDates({
     value,
     comparedValue,
+    component
   }) {
-    const date = moment(value);
-    const comparedDate = moment(comparedValue);
+    const dateFormat = this.setDateFormat(component);
+    const date = moment(value, dateFormat);
+    const comparedDate = moment(comparedValue, dateFormat);
 
     return {
       date,

--- a/test/actions.js
+++ b/test/actions.js
@@ -3799,6 +3799,75 @@ module.exports = (app, template, hook) => {
               ],
             },
             {
+              'label': 'Day with full date',
+              'hideInputLabels': false,
+              'inputsLabelPosition': 'top',
+              'useLocaleSettings': false,
+              'tableView': false,
+              'fields': {
+                  'day': {
+                      'hide': false
+                  },
+                  'month': {
+                      'hide': false
+                  },
+                  'year': {
+                      'hide': false
+                  }
+              },
+              'validateWhenHidden': false,
+              'key': 'day',
+              'type': 'day',
+              'input': true,
+              'defaultValue': ''
+            },
+            {
+              'label': 'Day with hidden day',
+              'hideInputLabels': false,
+              'inputsLabelPosition': 'top',
+              'useLocaleSettings': false,
+              'tableView': false,
+              'fields': {
+                  'day': {
+                      'hide': true
+                  },
+                  'month': {
+                      'hide': false
+                  },
+                  'year': {
+                      'hide': false
+                  }
+              },
+              'validateWhenHidden': false,
+              'key': 'day1',
+              'type': 'day',
+              'input': true,
+              'defaultValue': ''
+            },
+            {
+              'label': 'Day with hidden year',
+              'hideInputLabels': false,
+              'inputsLabelPosition': 'top',
+              'useLocaleSettings': false,
+              'tableView': false,
+              'fields': {
+                  'day': {
+                      'hide': false
+                  },
+                  'month': {
+                      'hide': false
+                  },
+                  'year': {
+                      'hide': true
+                  }
+              },
+              'validateWhenHidden': false,
+              'key': 'day2',
+              'type': 'day',
+              'input': true,
+              'defaultValue': ''
+            },
+            {
               type: 'button',
               label: 'Submit',
               key: 'submit',
@@ -4586,6 +4655,281 @@ module.exports = (app, template, hook) => {
               helper
                 .submission({
                   dateTime: '',
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test isEqual operator with Day component with full date', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'day',
+              operator: 'isEqual',
+              value: '01/01/2025',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              day: '02/01/2025',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  day: '01/01/2025',
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test isNotEqual operator with Day component with full date', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'day',
+              operator: 'isNotEqual',
+              value: '01/01/2025',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              day: '01/01/2025',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  day: '02/01/2025',
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test isEqual operator with Day component with hidden day', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'day1',
+              operator: 'isEqual',
+              value: '01/00/2025',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              day1: '02/00/2025',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  day1: '01/00/2025',
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test isNotEqual operator with Day component with day hidden', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'day1',
+              operator: 'isNotEqual',
+              value: '01/00/2025',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              day1: '01/00/2025',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  day1: '02/00/2025',
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test isEqual operator with Day component with hidden year', (done) => {
+        action.condition = {
+          conjunction: 'all',
+            conditions: [
+              {
+                component: 'day2',
+                operator: 'isEqual',
+                value: '01/01/0000',
+              },
+            ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              day2: '02/01/0000',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  day2: '01/01/0000',
+                })
+                .execute((err) => {
+                  if (err) {
+                    return done(err);
+                  }
+
+                  const submission = helper.getLastSubmission();
+                  assert(submission.hasOwnProperty('_id'));
+
+                  done();
+                });
+            });
+        });
+      });
+
+      it('Test isNotEqual operator with Day component with hidden year', (done) => {
+        action.condition = {
+          conjunction: 'all',
+          conditions: [
+            {
+              component: 'day2',
+              operator: 'isNotEqual',
+              value: '01/01/0000',
+            },
+          ],
+        };
+        helper.updateAction('actionsExtendedConditionalForm', action, (err) => {
+          if (err) {
+            done(err);
+          }
+
+          helper
+            .submission('actionsExtendedConditionalForm', {
+              day2: '01/01/0000',
+            }, helper.owner, [/application\/json/, 200])
+            .execute((err) => {
+              if (err) {
+                return done(err);
+              }
+
+              const submission = helper.getLastSubmission();
+              assert(!submission.hasOwnProperty('_id'));
+
+              helper
+                .submission({
+                  day2: '02/01/0000',
                 })
                 .execute((err) => {
                   if (err) {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8798


## Description

Incomplete date formats have been added to the getValidationFormat function for date validation (MM-YYYY, DD-MM etc.) Also added functionality that allows you to set the date format during validation only for the day component. The changes allow to correctly perform comparison of not full dates during the execution of actions.

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

https://github.com/formio/core/pull/140
https://github.com/formio/formio.js/pull/5760

## How has this PR been tested?
auto tests

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
