### PR TITLE
FIO-9099: fix various async problems

### DIFF
--- a/src/db/index.js
+++ b/src/db/index.js
@@ -66,6 +66,26 @@ module.exports = function(formio) {
   };
 
   /**
+   *
+   * @param {object} lock - The lock object to sanitize.
+   * @returns {object|undefined} - The sanitized lock object.
+   */
+  const sanitizeLock = function(lock) {
+    if (!lock) {
+      return;
+    }
+    if (typeof lock !== 'object') {
+      throw new Error('Invalid lock object');
+    }
+    const validLock = {
+      key: lock.key,
+      isLocked: lock.isLocked,
+      version: lock.version
+    };
+    return validLock;
+  };
+
+  /**
    * Unlock the formio lock.
    *
    *   The next function to invoke after this function has finished.
@@ -80,7 +100,7 @@ module.exports = function(formio) {
       {key: 'formio'},
       {$set: {isLocked: currentLock.isLocked}});
     const result = await schema.findOne({key: 'formio'});
-    currentLock = result;
+    currentLock = sanitizeLock(result);
     debug.db('Lock unlocked');
   };
   /**
@@ -420,21 +440,6 @@ module.exports = function(formio) {
         updates = files.sort(semver.compare);
         debug.db('Final updates');
       });
-  };
-
-  const sanitizeLock = function(lock) {
-    if (!lock) {
-      return;
-    }
-    if (typeof lock !== 'object') {
-      throw new Error('Invalid lock object');
-    }
-    const validLock = {
-      key: lock.key,
-      isLocked: lock.isLocked,
-      version: lock.version
-    };
-    return validLock;
   };
 
   /**

--- a/src/middleware/submissionHandler.js
+++ b/src/middleware/submissionHandler.js
@@ -420,7 +420,7 @@ module.exports = (router, resourceName, resourceId) => {
         return next();
       }
       catch (error) {
-        if(!res.headersSent){
+        if (!res.headersSent) {
           return next(error);
         }
       }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9099

## Description

Some changes made recently in #1766 didn't account for breaking changes in the MongoDB drivers, which no longer return an `ops` object from the `insertOne` method. This was causing an issue during schema and lock creation. This PR updates the lock creation function as well as fixes some other minor async JS issues.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

manually

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
