### PR TITLE
FIO-9064: refactor timeout to be part of config rather than function arg

### DIFF
--- a/index.js
+++ b/index.js
@@ -293,7 +293,17 @@ module.exports = function(config) {
 
           // Read the static VM depdenencies into memory and configure the VM
           const {lodash, moment, inputmask, core, fastJsonPatch, nunjucks} = require('./src/util/staticVmDependencies');
-          configureVm({lodash, moment, inputmask, core, fastJsonPatch, nunjucks});
+          configureVm({
+            dependencies: {
+              lodash,
+              moment,
+              inputmask,
+              core,
+              fastJsonPatch,
+              nunjucks
+            },
+            timeout: config.vmTimeout
+          });
 
           // Say we are done.
           router.formio.db = mongoose.connection;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@formio/core": "2.1.0-dev.129.a4f2d55",
     "@formio/js": "5.0.0-dev.5673.3d062b9",
     "@formio/node-fetch-http-proxy": "^1.1.0",
-    "@formio/vm": "1.0.0-dev.32.0743021",
+    "@formio/vm": "1.0.0-dev.35.6a055bc",
     "JSONStream": "^1.3.5",
     "adm-zip": "^0.5.9",
     "async": "^3.2.4",

--- a/src/actions/SaveSubmission.js
+++ b/src/actions/SaveSubmission.js
@@ -210,7 +210,6 @@ module.exports = function(router) {
                 submission: (res.resource && res.resource.item) ? res.resource.item : req.body,
                 data: submission.data,
               },
-              timeout: router.formio.config.vmTimeout,
             });
             submission = {...submission, ...newData};
             req.isTransformedData = true;

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -268,7 +268,6 @@ module.exports = (router) => {
               submission: params.submission,
               previous: params.previous,
             },
-            timeout: router.formio.config.vmTimeout,
           });
 
           return result;

--- a/src/middleware/submissionHandler.js
+++ b/src/middleware/submissionHandler.js
@@ -220,7 +220,6 @@ module.exports = (router, resourceName, resourceId) => {
           formModel,
           tokenModel,
           hook,
-          router.formio.config.vmTimeout
         );
         await validator.validate(req.body, (err, data, visibleComponents) => {
           if (req.noValidate) {
@@ -420,7 +419,7 @@ module.exports = (router, resourceName, resourceId) => {
         return next();
       }
       catch (error) {
-        if(!res.headersSent){
+        if (!res.headersSent) {
           return next(error);
         }
       }

--- a/src/resources/Validator.js
+++ b/src/resources/Validator.js
@@ -38,7 +38,7 @@ async function submissionQueryExists(submissionModel, query) {
  * @constructor
  */
 class Validator {
-  constructor(req, submissionModel, submissionResource, cache, formModel, tokenModel, hook, timeout = 500) {
+  constructor(req, submissionModel, submissionResource, cache, formModel, tokenModel, hook) {
     const tokens = {};
     const token = Utils.getRequestValue(req, 'x-jwt-token');
     if (token) {
@@ -65,7 +65,6 @@ class Validator {
     this.decodedToken = req.token;
     this.tokens = tokens;
     this.hook = hook;
-    this.timeout = timeout;
   }
 
   addPathQueryParams(pathQueryParams, query, path) {
@@ -334,7 +333,6 @@ class Validator {
         scope: context.scope,
         token: this.tokens['x-jwt-token'],
         tokens: this.tokens,
-        timeout: this.timeout,
         additionalDeps
       });
       context.scope = scope;

--- a/test/validator.js
+++ b/test/validator.js
@@ -166,7 +166,6 @@ module.exports = function(app, template, hook) {
         formio.resources.form.model,
         formio.mongoose.models.token,
         hook,
-        formio.config.vmTimeout
       );
       const dataTableComponent = {
         type: 'datatable',
@@ -228,7 +227,6 @@ module.exports = function(app, template, hook) {
         formio.resources.form.model,
         formio.mongoose.models.token,
         hook,
-        formio.config.vmTimeout
       );
       const dataTableComponent = {
         type: 'datatable',

--- a/yarn.lock
+++ b/yarn.lock
@@ -382,17 +382,17 @@
   resolved "https://registry.yarnpkg.com/@formio/vanilla-text-mask/-/vanilla-text-mask-5.1.1-formio.1.tgz#f53fc7f4cb37c6ae38f2857488055e781e5adba9"
   integrity sha512-rYBlvIPMNUd6sAaduOaiIwI4vfTAjHDRonko2qJn2RP1O//TQ7rcFIPYVYePJZ4OtOpwHiHAvAIh79McphZotQ==
 
-"@formio/vm@1.0.0-dev.32.0743021":
-  version "1.0.0-dev.32.743021"
-  resolved "https://registry.yarnpkg.com/@formio/vm/-/vm-1.0.0-dev.32.743021.tgz#b132f0c59a8da1aa1c7d2b78768634e652ea8d4f"
-  integrity sha512-fZ8uKBmC0o681vAz92lsjnVugmIqjuUh75bgWE6niiYf0jK32tcGl7hZ0I+U3jp242FoF2Hn2Ycf12xHC9E0lw==
+"@formio/vm@1.0.0-dev.35.6a055bc":
+  version "1.0.0-dev.35.6a055bc"
+  resolved "https://registry.yarnpkg.com/@formio/vm/-/vm-1.0.0-dev.35.6a055bc.tgz#3591acb97011ef26214111b64d3871d4ec4194e7"
+  integrity sha512-ot9yydwyi+6CwipQxlYJqx8FRjkPTgKlUDzA8M3bgZmjdIpkso8O4J2Gl1jEggTkCJUgZcSf5Wh0izHDzWWJcg==
   dependencies:
     "@formio/core" "2.1.0-dev.129.a4f2d55"
     "@formio/js" "5.0.0-rc.66"
     debug "^4.3.4"
     dotenv "^16.3.1"
     express "^4.18.2"
-    inputmask "^5.0.8"
+    inputmask "^5.0.9"
     isolated-vm "^4.6.0"
     lodash "^4.17.21"
     moment "^2.29.4"
@@ -2056,7 +2056,7 @@ inputmask@5.0.8:
   resolved "https://registry.yarnpkg.com/inputmask/-/inputmask-5.0.8.tgz#cd0f70b058c3291a0d4f27de25dbfc179c998bb4"
   integrity sha512-1WcbyudPTXP1B28ozWWyFa6QRIUG4KiLoyR6LFHlpT4OfTzRqFfWgHFadNvRuMN1S9XNVz9CdNvCGjJi+uAMqQ==
 
-inputmask@^5.0.8:
+inputmask@^5.0.8, inputmask@^5.0.9:
   version "5.0.9"
   resolved "https://registry.yarnpkg.com/inputmask/-/inputmask-5.0.9.tgz#7bf4e83f5e199c88c0edf28545dc23fa208ef4be"
   integrity sha512-s0lUfqcEbel+EQXtehXqwCJGShutgieOaIImFKC/r4reYNvX3foyrChl6LOEvaEgxEbesePIrw1Zi2jhZaDZbQ==


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9064

## Description

A `getCustomDefaultValue` method was added to the InstanceShim class in @formio/vm, which required an ad-hoc evaluation of component JSON properties. To ensure that the timeout is able to be configured for all evaluations, the `configureVM` method was refactored to include a global timeout. This PR updates the downstream code to correspond to those changes made in [@formio/vm#35](https://github.com/formio/vm/pull/35).

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

* https://github.com/formio/vm/pull/35

## How has this PR been tested?

n/a

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
