### PR TITLE
FIO-9064: refactor timeout to be part of config rather than function arg

### DIFF
--- a/index.js
+++ b/index.js
@@ -326,19 +326,6 @@ module.exports = function(config) {
 
         // Add submission data export capabilities.
         require('./src/export/export')(router);
-          // Read the static VM depdenencies into memory and configure the VM
-          const {lodash, moment, inputmask, core, fastJsonPatch, nunjucks} = require('./src/util/staticVmDependencies');
-          configureVm({
-            dependencies: {
-              lodash,
-              moment,
-              inputmask,
-              core,
-              fastJsonPatch,
-              nunjucks
-            },
-            timeout: config.vmTimeout
-          });
 
         // Add the available templates.
         router.formio.templates = {
@@ -367,7 +354,17 @@ module.exports = function(config) {
 
         // Read the static VM depdenencies into memory and configure the VM
         const {lodash, moment, inputmask, core, fastJsonPatch, nunjucks} = require('./src/util/staticVmDependencies');
-        configureVm({lodash, moment, inputmask, core, fastJsonPatch, nunjucks});
+        configureVm({
+          dependencies: {
+            lodash,
+            moment,
+            inputmask,
+            core,
+            fastJsonPatch,
+            nunjucks
+          },
+          timeout: config.vmTimeout
+        });
 
         // Say we are done.
         deferred.resolve(router.formio);

--- a/index.js
+++ b/index.js
@@ -326,6 +326,19 @@ module.exports = function(config) {
 
         // Add submission data export capabilities.
         require('./src/export/export')(router);
+          // Read the static VM depdenencies into memory and configure the VM
+          const {lodash, moment, inputmask, core, fastJsonPatch, nunjucks} = require('./src/util/staticVmDependencies');
+          configureVm({
+            dependencies: {
+              lodash,
+              moment,
+              inputmask,
+              core,
+              fastJsonPatch,
+              nunjucks
+            },
+            timeout: config.vmTimeout
+          });
 
         // Add the available templates.
         router.formio.templates = {

--- a/src/util/staticVmDependencies.js
+++ b/src/util/staticVmDependencies.js
@@ -1,6 +1,8 @@
 'use strict';
 const fs = require('fs');
 const resolve = require('resolve/sync');
+const lodashPath = resolve('lodash/lodash.min.js');
+console.log('Lodash Path:', lodashPath);
 
 const lodashCode = fs.readFileSync(resolve('lodash/lodash.min.js'), 'utf8');
 const momentCode = fs.readFileSync(resolve('moment/min/moment.min.js'), 'utf8');

--- a/src/util/staticVmDependencies.js
+++ b/src/util/staticVmDependencies.js
@@ -1,8 +1,6 @@
 'use strict';
 const fs = require('fs');
 const resolve = require('resolve/sync');
-const lodashPath = resolve('lodash/lodash.min.js');
-console.log('Lodash Path:', lodashPath);
 
 const lodashCode = fs.readFileSync(resolve('lodash/lodash.min.js'), 'utf8');
 const momentCode = fs.readFileSync(resolve('moment/min/moment.min.js'), 'utf8');


### PR DESCRIPTION
PR made specifically for 4.3.x branch.

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9064

## Description

A `getCustomDefaultValue` method was added to the InstanceShim class in @formio/vm, which required an ad-hoc evaluation of component JSON properties. To ensure that the timeout is able to be configured for all evaluations, the `configureVM` method was refactored to include a global timeout. This PR updates the downstream code to correspond to those changes made in [@formio/vm#35](https://github.com/formio/vm/pull/35).

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

* https://github.com/formio/vm/pull/35

## How has this PR been tested?

n/a

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
