### PR TITLE
FIO-9006: Added Last-Modified response header on form index request

### DIFF
--- a/src/middleware/lastModifiedIndexHandler.js
+++ b/src/middleware/lastModifiedIndexHandler.js
@@ -1,0 +1,67 @@
+'use strict';
+const _ = require('lodash');
+
+/**
+ * Middleware function to set the lastModified in the response header.
+ *
+ * @param req
+ * @param res
+ * @param next
+ * @returns {*}
+ */
+module.exports = function(router) {
+  return async function lastModifiedIndexHandler(req, res, next) {
+    if (
+      req.method !== 'GET' ||
+      req.formId ||
+      (_.get(req, '__rMethod', 'get') !== 'index')
+    ) {
+      return next();
+    }
+
+    try {
+      const {deleted, ...matchObj} = req.modelQuery._conditions ?? {};
+      if (matchObj.hasOwnProperty('tags') && typeof matchObj.tags === 'string') {
+        matchObj.tags = {$in: matchObj.tags.split(',')};
+      }
+      const result = await router.formio.resources.form.model
+        .aggregate([
+          {
+            '$match': matchObj
+          },
+          {
+            '$project': {
+              'lastModified': {
+                '$cond': {
+                  'if': {'$ne': ['$deleted', null]},
+                  'then': {
+                    '$cond': {
+                      'if': {'$gt': ['$deleted', 0]},
+                      'then': {'$max': ['$modified', {'$toDate': '$deleted'}]},
+                      'else': '$modified'
+                    }
+                  },
+                  'else': '$modified'
+                }
+              }
+            }
+          },
+          {
+            '$sort': {'lastModified': -1}
+          },
+          {
+            '$limit': 1
+          }
+        ]);
+      if (result.length) {
+        res.setHeader('Last-Modified', result[0].lastModified.toUTCString());
+      }
+    }
+    catch (err) {
+      console.warn(err.message);
+      return next();
+    }
+
+    next();
+  };
+};

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -40,6 +40,7 @@ module.exports = function(router) {
     filterIndex: require('./filterIndex')(router),
     mongodbConnectionState: require('./mongodbConnectionState')(router),
     formRevisionLoader: require('./formRevisionLoader')(router),
-    submissionRevisionLoader: require('./submissionRevisionLoader')(router)
+    submissionRevisionLoader: require('./submissionRevisionLoader')(router),
+    lastModifiedIndexHandler: require('./lastModifiedIndexHandler')(router),
   };
 };

--- a/src/resources/FormResource.js
+++ b/src/resources/FormResource.js
@@ -80,7 +80,8 @@ module.exports = function(router) {
         router.formio.middleware.formLoader,
         router.formio.middleware.formActionHandler('after'),
         router.formio.middleware.filterResourcejsResponse(['deleted', '__v']),
-        router.formio.middleware.filterIndex(['components', 'properties'])
+        router.formio.middleware.filterIndex(['components', 'properties']),
+        router.formio.middleware.lastModifiedIndexHandler,
       ],
       hooks: {
         put: {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9006

## Description

**Issue**: The issue is described in this [PR](https://github.com/formio/angular/pull/1104). As mentioned, it's not a good idea to simply disable the cache. Instead, we can use the `Last-Modified` response header to get the last modified date of the requested forms.

**Solution**: Apply filters from the original request and find the last date of any modification (create, update, delete) in that selection. Set this date as the `Last-Modified` response header. The browser will use this to set the `If-Modified-Since` request header in future requests. If there are no modifications since this time, the server will respond with a 304 status code.

Added the ability to check the execution timing using the PERFORMANCE_TIMER environment variable.

## How has this PR been tested?

Unit tests, manually 

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
