### PR TITLE
4.2.x-4.3.x - FIO-9306: fixed an issue where nested forms do not show data in PDF

### DIFF
--- a/src/cache/cache.js
+++ b/src/cache/cache.js
@@ -1,6 +1,7 @@
 'use strict';
 const async = require('async');
 const _ = require('lodash');
+const promisify = require('util').promisify;
 const debug = {
   form: require('debug')('formio:cache:form'),
   loadForm: require('debug')('formio:cache:loadForm'),
@@ -566,12 +567,18 @@ module.exports = function(router) {
               }
 
               // Load all subdata within this submission.
-              submissionPromises.push(this.loadSubSubmissions(subInfo.component, sub, req, () => {}, depth + 1));
+              submissionPromises.push(this.loadSubSubmissionsPromisified(subInfo.component, sub, req, depth + 1));
             });
             Promise.all(submissionPromises).then(() => nextSubmission()).catch(() => nextSubmission());
           }
         }, next);
       });
-    }
+    },
+
+    loadSubSubmissionsPromisified: promisify(
+      function(form, submission, req, depth, next) {
+        return this.loadSubSubmissions(form, submission, req, next, depth);
+      }
+    )
   };
 };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9306

## Description

**What changed?**

The 'loadSubSubmissions' does not wait when all subSubmissions are loaded. This causes the formio-server to send a submission object without subSubmissions attached to pdf-server. This PR fixes it.
There is no this issue on the master branch as master does not use callbacks.

## How has this PR been tested?

Manually with pdf-server.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
