### PR TITLE
FIO-9365: allow incomplete req object for Validator constructor

### DIFF
--- a/src/util/util.js
+++ b/src/util/util.js
@@ -306,7 +306,7 @@ const Utils = {
    *   The header value if found or false.
    */
   getHeader(req, key) {
-    if (typeof req.headers[key] !== 'undefined') {
+    if (req.headers && typeof req.headers[key] !== 'undefined') {
       return req.headers[key];
     }
 
@@ -325,7 +325,7 @@ const Utils = {
    *   The query value if found or false.
    */
   getQuery(req, key) {
-    if (typeof req.query[key] !== 'undefined') {
+    if (req.query && typeof req.query[key] !== 'undefined') {
       return req.query[key];
     }
 
@@ -344,7 +344,7 @@ const Utils = {
    *   The parameter value if found or false.
    */
   getParameter(req, key) {
-    if (typeof req.params[key] !== 'undefined') {
+    if (req.params && typeof req.params[key] !== 'undefined') {
       return req.params[key];
     }
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9365

## Description

**What changed?**

`Validator` constructor now allows passing `req` object lacking `headers`, `query` or `params`

## Breaking Changes / Backwards Compatibility

the fact that it's not going to throw now is a breaking change technically, but I don't think it's going to affect anybody

## Dependencies

n/a

## How has this PR been tested?

Tested in sandbox

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
