### PR TITLE
FIO-9308: Fixed an issue where nested forms that start with the same keys submit the wrong data.

### DIFF
--- a/src/actions/fields/form.js
+++ b/src/actions/fields/form.js
@@ -31,9 +31,13 @@ module.exports = (router) => {
     const isConditionallyHidden = () => {
       const submission = req.body;
       return _.some(
-          submission?.scope?.conditionals || [],
-          condComp => condComp.conditionallyHidden && (condComp.path === path || _.startsWith(path, condComp.path))
-        );
+        submission?.scope?.conditionals || [],
+        condComp => condComp.conditionallyHidden && (
+          condComp.path === path ||
+          _.startsWith(path, `${condComp.path}.`) ||
+          _.startsWith(path, `${condComp.path}[`)
+        )
+      );
     };
     // Only execute if the component should save reference and conditions do not apply.
     if (

--- a/test/submission.js
+++ b/test/submission.js
@@ -5232,6 +5232,7 @@ module.exports = function(app, template, hook) {
         .execute(done);
     });
 
+    let nestedSubmission = null;
     it('Should allow you to submit data into a conditionally visible form if another nested form is conditionally hidden', (done) => {
       helper.submission('parentForm2', {
         radio: 'b',
@@ -5246,13 +5247,27 @@ module.exports = function(app, template, hook) {
           return done(err);
         }
 
-        assert.equal(helper.lastSubmission.data.radio, 'b');
-        assert.equal(helper.lastSubmission.data.form2.data.textFieldForm3, 'Hello');
+        nestedSubmission = helper.lastSubmission;
+        assert.equal(nestedSubmission.data.radio, 'b');
+        assert.equal(nestedSubmission.data.form2.data.textFieldForm3, 'Hello');
         done();
       });
     });
 
-    let nestedSubmission = null;
+    it('Should allow you to update data into a conditionally visible form if another nested form is conditionally hidden', (done) => {
+      nestedSubmission.data.form2.data.textFieldForm3 = 'Hello Update';
+      helper.submission('parentForm2', nestedSubmission).execute((err) => {
+        if (err) {
+          return done(err);
+        }
+
+        nestedSubmission = helper.lastSubmission;
+        assert.equal(nestedSubmission.data.radio, 'b');
+        assert.equal(nestedSubmission.data.form2.data.textFieldForm3, 'Hello Update');
+        done();
+      });
+    });
+
     it('Should let you create a submission without errors', (done) => {
       helper.submission('parentForm1', {
         radio: 'b',

--- a/test/submission.js
+++ b/test/submission.js
@@ -5010,7 +5010,7 @@ module.exports = function(app, template, hook) {
 
     before('Create the child form1', (done) => {
       helper
-        .form('form1', [
+        .form('childForm1', [
           {
             label: 'Text Field form1',
             applyMaskOn: 'change',
@@ -5037,7 +5037,7 @@ module.exports = function(app, template, hook) {
 
     before('Create the child form2', (done) => {
       helper
-        .form('form2', [
+        .form('childForm2', [
           {
             label: 'Text Field - form2',
             applyMaskOn: 'change',
@@ -5053,7 +5053,7 @@ module.exports = function(app, template, hook) {
           {
             label: 'Form',
             tableView: true,
-            form: helper.template.forms.form1._id,
+            form: helper.template.forms.childForm1._id,
             useOriginalRevision: false,
             key: 'form',
             type: 'form',
@@ -5071,9 +5071,36 @@ module.exports = function(app, template, hook) {
         .execute(done);
     });
 
+    before('Create the child form3', (done) => {
+      helper
+        .form('childForm3', [
+          {
+            label: 'Text Field - form3',
+            applyMaskOn: 'change',
+            tableView: true,
+            validate: {
+              required: true,
+            },
+            validateWhenHidden: false,
+            key: 'textFieldForm3',
+            type: 'textfield',
+            input: true,
+          },
+          {
+            type: 'button',
+            label: 'Submit',
+            key: 'submit',
+            disableOnInvalid: true,
+            input: true,
+            tableView: false,
+          },
+        ])
+        .execute(done);
+    });
+
     before('Create the parent form', (done) => {
       helper
-        .form('form3', [
+        .form('parentForm1', [
           {
             label: 'Radio',
             optionsLabelPosition: 'right',
@@ -5099,7 +5126,7 @@ module.exports = function(app, template, hook) {
           {
             label: 'Form',
             tableView: true,
-            form: helper.template.forms.form2._id,
+            form: helper.template.forms.childForm2._id,
             useOriginalRevision: false,
             key: 'form',
             conditional: {
@@ -5128,9 +5155,106 @@ module.exports = function(app, template, hook) {
         .execute(done);
     });
 
+    before('Create the parent form 2', (done) => {
+      helper
+        .form('parentForm2', [
+          {
+            label: 'Radio',
+            optionsLabelPosition: 'right',
+            inline: false,
+            tableView: false,
+            values: [
+              {
+                label: 'a',
+                value: 'a',
+                shortcut: '',
+              },
+              {
+                label: 'b',
+                value: 'b',
+                shortcut: '',
+              },
+            ],
+            validateWhenHidden: false,
+            key: 'radio',
+            type: 'radio',
+            input: true,
+          },
+          {
+            label: 'Form',
+            tableView: true,
+            form: helper.template.forms.childForm1._id,
+            useOriginalRevision: false,
+            key: 'form',
+            conditional: {
+              show: true,
+              conjunction: 'all',
+              conditions: [
+                {
+                  component: 'radio',
+                  operator: 'isEqual',
+                  value: 'a',
+                },
+              ],
+            },
+            type: 'form',
+            input: true,
+          },
+          {
+            label: 'Form 2',
+            tableView: true,
+            form: helper.template.forms.childForm3._id,
+            useOriginalRevision: false,
+            key: 'form2',
+            conditional: {
+              show: true,
+              conjunction: 'all',
+              conditions: [
+                {
+                  component: 'radio',
+                  operator: 'isEqual',
+                  value: 'b',
+                },
+              ],
+            },
+            type: 'form',
+            input: true,
+          },
+          {
+            type: 'button',
+            label: 'Submit',
+            key: 'submit',
+            disableOnInvalid: true,
+            input: true,
+            tableView: false,
+          },
+        ])
+        .execute(done);
+    });
+
+    it('Should allow you to submit data into a conditionally visible form if another nested form is conditionally hidden', (done) => {
+      helper.submission('parentForm2', {
+        radio: 'b',
+        submit: true,
+        form2: {
+          data: {
+            textFieldForm3: 'Hello'
+          }
+        }
+      }).execute((err) => {
+        if (err) {
+          return done(err);
+        }
+
+        assert.equal(helper.lastSubmission.data.radio, 'b');
+        assert.equal(helper.lastSubmission.data.form2.data.textFieldForm3, 'Hello');
+        done();
+      });
+    });
+
     let nestedSubmission = null;
     it('Should let you create a submission without errors', (done) => {
-      helper.submission('form3', { 
+      helper.submission('parentForm1', {
         radio: 'b',
         submit: true
       }).execute((err) => {
@@ -5145,7 +5269,7 @@ module.exports = function(app, template, hook) {
     });
     
     it('Should allow you to submit data to the nested form.', (done) => {
-      helper.submission('form3', { 
+      helper.submission('parentForm1', {
         radio: 'a',
         form: {
           data: {
@@ -5174,7 +5298,7 @@ module.exports = function(app, template, hook) {
     it('Should allow you to update data to the nested form.', (done) => {
       nestedSubmission.data.form.data.textFieldForm2 = 'Foo 1';
       nestedSubmission.data.form.data.form.data.textFieldForm1 = 'Bar 1';
-      helper.submission('form3', nestedSubmission).execute((err) => {
+      helper.submission('parentForm1', nestedSubmission).execute((err) => {
         if (err) {
           return done(err);
         }
@@ -5185,7 +5309,7 @@ module.exports = function(app, template, hook) {
     });
 
     it('Should have updated the data of the nested forms.', (done) => {
-      helper.getSubmission('form3', nestedSubmission._id, function(err, submission) {
+      helper.getSubmission('parentForm1', nestedSubmission._id, function(err, submission) {
         if (err) {
           done(err);
         }


### PR DESCRIPTION

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9308

## Description

The issue only occurs if there are two nested forms that have keys that "startWith" the same characters. Such as "form" and "form1".  In this case, the data of "form1" could be affected if the conditions of "form" are conditionally hidden. In this case the "startsWith" actually returns true because "form1" starts with "form". 

I solved this problem by changing the "startsWith" to take into account that this may be a "parent" path which would always contain either a "." or a "[" in the startsWith check. This ensures that the following will be true.

  "container.form" => will pass if the container is conditionally hidden since "container.form" starts with "container."
  "form" => will not pass since "form1" does NOT start with "form."

## Breaking Changes / Backwards Compatibility

None

## Dependencies

None

## How has this PR been tested?

A new automated test was added.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
