### PR TITLE
CHORE: update error handling to not throw lock error

### DIFF
--- a/src/db/index.js
+++ b/src/db/index.js
@@ -230,7 +230,12 @@ module.exports = function(formio) {
       }
        catch (err) {
         debug.db(`Connection Error: ${err}`);
-        await unlock();
+        try {
+          await unlock();
+        }
+        catch (ignoreErr) {
+          debug.db(`Unlock Error: ${ignoreErr}`);
+        }
         throw new Error(`Could not connect to the given Database for server updates: ${dbUrl}.`);
       }
     }
@@ -744,7 +749,7 @@ module.exports = function(formio) {
         await unlock();
         return db;
       }
-      catch (err) {
+      catch (ignoreErr) {
         debug.db(err);
         throw err;
       }


### PR DESCRIPTION
## Link to Jira Ticket

n/a

## Description

Upon a db related error, the server will attempt to unlock. This will fail in the case of e.g. database connection errors, because there is no database to unlock. This PR updates error handling to throw the correct error rather than always throwing the unlock error. 

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
