### PR TITLE
Update README to include Docker Compose v2 command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ The fastest way to run this library locally is to use [Docker](https://docker.co
     ```
     docker-compose up -d
     ```
+   For the docker compose v2 use this command
+    ```
+   docker compose up -d
+    ```
 
     Or, if you have an older version of the Docker image on your machine
     ```bash


### PR DESCRIPTION
## Description

**What changed?**

Made a small change by add the new version of the docker compose command of v2 and added the tests for the working of the command in my machine which is a ubuntu 24.04 version.

**Why have you chosen this solution?**
 I got an error when i ran the old command in the docker usage steps in the readme.

It will be useful for the people who are new to docker or struggling to setup docker compose files.

## Breaking Changes / Backwards Compatibility

If this is not solved then this error will rise when the dev's  using the latest version of docker compose.

Error will be 

```
    Traceback (most recent call last):
  File "/usr/bin/docker-compose", line 33, in <module>
    sys.exit(load_entry_point('docker-compose==1.29.2', 'console_scripts', 'docker-compose')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/docker-compose", line 25, in importlib_load_entry_point
    return next(matches).load()
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/importlib/metadata/__init__.py", line 205, in load
    module = import_module(match.group('module'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/usr/lib/python3/dist-packages/compose/cli/main.py", line 9, in <module>
    from distutils.spawn import find_executable
ModuleNotFoundError: No module named 'distutils'
 
```

## Dependencies

Made a small change the readme of the form.io and it resolves the issue of #1875 

## How has this PR been tested?

[Screencast from 2024-12-31 00-26-03.webm](https://github.com/user-attachments/assets/47bf08cf-03f6-4840-a8f3-cdc4a10ae5a2)


## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
