### PR TITLE
FIO-9499: Add test for email action with edit grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@formio/core": "2.4.0-dev.2",
     "@formio/js": "5.1.0-dev.5977.69f20ee",
     "@formio/node-fetch-http-proxy": "^1.1.0",
-    "@formio/vm": "1.0.0-dev.44.59b3edc",
+    "@formio/vm": "1.0.0-dev.45.7e9ae31",
     "JSONStream": "^1.3.5",
     "adm-zip": "^0.5.9",
     "async": "^3.2.4",

--- a/test/actions.js
+++ b/test/actions.js
@@ -9,6 +9,7 @@ const http = require('http');
 const url = require('url');
 const { UV_FS_O_FILEMAP } = require('constants');
 const testMappingDataForm = require('./fixtures/forms/testMappingDataForm');
+const { wait } = require('./util');
 const docker = process.env.DOCKER;
 
 module.exports = (app, template, hook) => {
@@ -1844,6 +1845,102 @@ module.exports = (app, template, hook) => {
               }
             });
         }, addSettings);
+      });
+        
+      it('Should send email with edit grid value', async () => {
+        let testAction = {
+          title: 'Email',
+          name: 'email',
+          handler: ['after'],
+          method: ['create'],
+          priority: 1,
+          settings: {
+            from: 'travis@form.io',
+            replyTo: '',
+            emails: ['test@form.io'],
+            sendEach: false,
+            subject: 'Hello',
+            message: '{{ submission(data, form.components) }}',
+            transport: 'test',
+            template: 'https://pro.formview.io/assets/email.html',
+            renderingMethod: 'dynamic'
+          },
+        }
+        const form = {
+          "_id": "677801142628e5aad5e7b1c2",
+          "title": "editGridEmail",
+          "name": "editGridEmail",
+          "path": "editGridEmail",
+          "type": "form",
+          "access": [],
+          "submissionAccess": [],
+          "components": [
+            {
+              "label": "Edit Grid",
+              "rowDrafts": false,
+              "key": "editGrid",
+              "type": "editgrid",
+              "displayAsTable": false,
+              "input": true,
+              "components": [
+                {
+                  "label": "Text Field",
+                  "key": "textField",
+                  "type": "textfield",
+                  "input": true
+                }
+              ]
+            }
+          ]
+        }
+  
+        const editGridForm = (await request(app)
+            .post(hook.alter('url', '/form', template))
+            .set('x-jwt-token', template.users.admin.token)
+            .send(form)).body;
+  
+        testAction.form = editGridForm._id;
+        // Add the action to the form.
+        const testActionRes = (await request(app)
+            .post(hook.alter('url', `/form/${editGridForm._id}/action`, template))
+            .set('x-jwt-token', template.users.admin.token)
+            .send(testAction)).body;
+  
+          
+        testAction = testActionRes;
+
+        let emailSent = false;
+
+        const event = template.hooks.getEmitter();
+        event.on('newMail', (email) => {
+          assert(email.html.includes('editGridString'));
+          event.removeAllListeners('newMail');
+          emailSent = true;
+        });
+
+        const submission = {
+          noValidate: true,
+          data: {
+            editGrid: [
+              {
+                textField: 'editGridString'
+              }
+            ],
+            submit: true
+          },
+          state: 'submitted'
+        };
+        // Send submission
+        await request(app)
+          .post(hook.alter('url', `/form/${editGridForm._id}/submission`, template))
+          .set('x-jwt-token', template.users.admin.token)
+          .send(submission);
+
+        
+
+        await wait(600);
+
+        assert(emailSent)
       });
 
       if (template.users.formioAdmin) {

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,6 @@
+module.exports = {
+    wait: (ms) => {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+    }
+};
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -280,10 +280,10 @@
   resolved "https://registry.yarnpkg.com/@formio/vanilla-text-mask/-/vanilla-text-mask-5.1.1-formio.1.tgz#f53fc7f4cb37c6ae38f2857488055e781e5adba9"
   integrity sha512-rYBlvIPMNUd6sAaduOaiIwI4vfTAjHDRonko2qJn2RP1O//TQ7rcFIPYVYePJZ4OtOpwHiHAvAIh79McphZotQ==
 
-"@formio/vm@1.0.0-dev.44.59b3edc":
-  version "1.0.0-dev.44.59b3edc"
-  resolved "https://registry.yarnpkg.com/@formio/vm/-/vm-1.0.0-dev.44.59b3edc.tgz#542a17aa1204d6e173746d59b3ab71f40b053502"
-  integrity sha512-2RNJ7oLA5+mpoBvm1sgYn0vKdipxnweGjCxymDEUYONtVxORd/SKv2tlnSlPo7DLA/E04y0rhOVECIfl13NVrw==
+"@formio/vm@1.0.0-dev.45.7e9ae31":
+  version "1.0.0-dev.45.7e9ae31"
+  resolved "https://registry.yarnpkg.com/@formio/vm/-/vm-1.0.0-dev.45.7e9ae31.tgz#f625fbe62032c14c546313bffc328cf3c87803ff"
+  integrity sha512-93RhdZXr0xIVKgR/M8YkUmhai8zhsG08m9Ca6Z/uxO90XqtNMdD/XL2fEdO8RXciGzdAb++UsD+PaH6EwxoVPw==
   dependencies:
     "@formio/core" "2.4.0-dev.2"
     "@formio/js" "5.1.0-dev.5977.69f20ee"


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9499

## Description

**What changed?**

Updated `@formio/vm` to include a browser mock for the `NodeList` object. When `formio` tried rendering an email template containing an edit grid, it called the `deatch()` method on the `Component` class in `formio.js`, which referenced the `NodeList` object, which was undefined on the server. I've updated `@formio/vm` with a mock for when `formio.js` code is executing server-side.

**Why have you chosen this solution?**

See `@formio/vm` PR.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

https://github.com/formio/vm/pull/45

## How has this PR been tested?

Automated test that fires an email action to render an email template representing a submission containing an edit grid. 

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable) 
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
