### PR TITLE
FIO-9471fixed the display of data for components inside layout components

### DIFF
--- a/test/export/CSVExporter/CSVExporter.js
+++ b/test/export/CSVExporter/CSVExporter.js
@@ -224,6 +224,36 @@ module.exports = function (app, template, hook) {
         });
     });
 
+    it('Should display data for Components inside the Layout Components', (done) => {
+      let owner = (app.hasProjects || docker) ? template.formio.owner : template.users.admin;
+      helper = new Helper(owner);
+      helper
+        .project()
+        .form('panelTest', wizardTest.components)
+        .submission({
+          data: {
+            number: 2,
+            textField: 'test Form',
+            textArea: 'test Form New'
+          }
+        })
+        .execute((err) => {
+          if (err) {
+            return done(err);
+          }
+          helper.getExport(helper.template.forms.panelTest, 'csv', (error, result) => {
+            if (error) {
+              return done(error);
+            }
+            assert.strictEqual(helper.template.forms.panelTest.display, 'form');
+            assert.strictEqual(getComponentValue(result.text, 'page1.number', 0), '"2"');
+            assert.strictEqual(getComponentValue(result.text, 'page2.textField', 0), '"test Form"');
+            assert.strictEqual(getComponentValue(result.text, 'page2.textArea', 0), '"test Form New"');
+            done();
+          });
+        });
+    });
+
     it(`Test Azure address data`, (done) => {
       let owner = (app.hasProjects || docker) ? template.formio.owner : template.users.admin;
       helper = new Helper(owner);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9471

## Description

*The issue of displaying data on the CSV Export page is relevant not only for Wizard Forms, but also for regular Forms with components that are located inside the Component Layout. The problem was fixed by searching the submission data using dataPath.*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*n/a*

## How has this PR been tested?

*Automated test has been added/ All tests pass locally*

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
