### PR TITLE
GH-1925: removed duplicate index creation

### DIFF
--- a/src/models/Submission.js
+++ b/src/models/Submission.js
@@ -93,16 +93,5 @@ module.exports = function(formio) {
     next();
   });
 
-  model.schema.index({
-    deleted: 1
-  });
-
-  // Add a "recommmended" combined index.
-  model.schema.index({
-    form: 1,
-    deleted: 1,
-    created: -1
-  });
-
   return model;
 };


### PR DESCRIPTION
## Link to Jira Ticket

https://github.com/formio/formio/issues/1925

## Description

**What changed?**

Remove schema.index calls

**Why have you chosen this solution?**

This was causing warning on startup
We already create these indexes with
model.schema.index(hook.alter('schemaIndex', {deleted: 1}));
model.schema.index(hook.alter('schemaIndex', {form: 1, deleted: 1}));
model.schema.index(hook.alter('schemaIndex', {form: 1, deleted: 1, created: -1}));


## Breaking Changes / Backwards Compatibility

N/A

## Dependencies

N/A

## How has this PR been tested?

manually tested

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
