### PR TITLE
FIO-9616: remove deprecated resourcefield

### DIFF
--- a/src/actions/SaveSubmission.js
+++ b/src/actions/SaveSubmission.js
@@ -35,13 +35,19 @@ module.exports = function(router) {
     static settingsForm(req, res, next) {
       next(null, [
         {
-          type: 'resourcefields',
+          type: 'select',
+          label: 'Save submission to',
+          authenticate: true,
+          valueProperty: '_id',
+          template: '<span>{{ item.title }}</span>',
+          searchField: 'title__regex',
           key: 'resource',
-          title: 'Save submission to',
-          placeholder: 'This form',
-          basePath: hook.alter('path', '/form', req),
-          form: req.params.formId,
-          required: false
+          lazyLoad: false,
+          tooltip: 'Select the Resource to save submissions to.',
+          dataSrc: 'url',
+          data: {
+            url: router.formio.hook.alter('path', `/form?type=resource`, req)
+          }
         }
       ]);
     }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9587

## Description

Deprecated resourcefield was replaced by select component for Save Submission action.

## Dependencies

-

## How has this PR been tested?
manually

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
