### PR TITLE
FIO-9789: update needless synchronous throttle to fix error handling in email action

### DIFF
--- a/src/actions/EmailAction.js
+++ b/src/actions/EmailAction.js
@@ -232,7 +232,7 @@ module.exports = (router) => {
           await emailer.send(req, res, settings, params, setActionItemMessage);
           setActionItemMessage('Message Sent');
         }
- catch (err) {
+        catch (err) {
           setActionItemMessage('Error sending message', {
             message: err.message || err
           }, 'error');

--- a/src/util/email.js
+++ b/src/util/email.js
@@ -489,34 +489,8 @@ module.exports = (formio) => {
           }, Promise.resolve());
       });
 
-      const throttledSendEmails = _.throttle(sendEmails , NON_PRIORITY_QUEUE_TIMEOUT);
-      const sendWithUser = async () => {
-        try {
-          const response = await sendEmails();
-          return response;
-        }
-        catch (err) {
-          debug.error(err);
-          throw new Error(err);
-        }
-      };
-
-      const sensWithoutUser = () => {
-        try {
-          throttledSendEmails();
-        }
-        catch (err) {
-          debug.error(err);
-          throw new Error(err);
-        }
-      };
-
-      if (req.user) {
-        return await sendWithUser();
-      }
-      else {
-        return await sensWithoutUser();
-      }
+      const response = await sendEmails();
+      return response;
     };
 
     const isTransportValid = (transporter) => !transporter || typeof transporter.sendMail !== 'function';
@@ -529,7 +503,7 @@ module.exports = (formio) => {
         ? message.transport
         : 'default';
 
-     const _config = (formio && formio.config && formio.config.email && formio.config.email.type);
+      const _config = (formio && formio.config && formio.config.email && formio.config.email.type);
       debug.send(message);
       debug.send(emailType);
       // Get the settings.


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9789

## Description

At some point, we attempted to add rate limiting to our email action, but took the wrong approach.

```javascript
const throttledSendEmails = _.throttle(sendEmails , NON_PRIORITY_QUEUE_TIMEOUT);
/* ... */
if (!req.user) {
  try {
    throttledSendEmails();
  }
  catch (err) {
    debug.error(err);
    throw new Error(err);
  }
} else {
  try {
    const response = await sendEmails;
    return response;
  }
  catch (err) {
    debug.error(err);
    throw new Error(err);
  }
}
```

This has a couple of issues:
1. This doesn't meaningfully rate limit across requests; `sendEmails` is always only called once per request, so each "throttled" function will be created anew with each subsequent request, meaning the rate limiting problem is still there.
2. Since `_.throttle` returns a synchronous function that we've passed an asynchronous function to, the try/catch block will not actually catch any errors, leading to this ticket's bug (an error in the 'checkEmailPermission' hook was uncaught).

Another PR will solve the rate limiting problem, but this PR should serve as a fix for the bug in question.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Testing this specific bug (which is an error thrown from a formio-server hook) is difficult because currently tests are broken when in a "hosted" configuration. I have tested manually though, and created a ticket to fix tests in a hosted configuration.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
