### PR TITLE
FIO 9814: fix problem with unique validation for email components

### DIFF
--- a/src/middleware/submissionHandler.js
+++ b/src/middleware/submissionHandler.js
@@ -9,6 +9,7 @@ module.exports = (router, resourceName, resourceId) => {
   const hook = require('../util/hook')(router.formio);
   const fActions = require('../actions/fields')(router);
   const pActions = require('../actions/properties')(router);
+  const config = router.formio.config;
   const handlers = {};
 
   // Iterate through the possible handlers.
@@ -220,6 +221,7 @@ module.exports = (router, resourceName, resourceId) => {
           formModel,
           tokenModel,
           hook,
+          config
         );
         await validator.validate(req.body, (err, data, visibleComponents) => {
           if (req.noValidate) {

--- a/test/submission.js
+++ b/test/submission.js
@@ -2836,7 +2836,7 @@ module.exports = function(app, template, hook) {
           ];
         const values = {
           email: 'brendan@form.io',
-          textField: 'I am a unique snowflake'
+          textField: 'IAmAUniqueSnowflake'
         }
         helper
           .form('uniqueTest', components)
@@ -2844,9 +2844,9 @@ module.exports = function(app, template, hook) {
           .expect(201)
           .execute(function(err) {
             if (err) {
-              done(err);
+              return done(err);
             }
-            done();
+            return done();
           });
       });
 
@@ -2928,7 +2928,7 @@ module.exports = function(app, template, hook) {
         ];
         const values = {
           email: 'brendan@form.io',
-          textField: 'I am a unique snowflake'
+          textField: 'IAmAUniqueSnowflake'
         };
 
         helper

--- a/test/submission.js
+++ b/test/submission.js
@@ -50,7 +50,7 @@ module.exports = function(app, template, hook) {
             done();
           });
       });
-   
+
       it('Saves values for each single value component type2', function(done) {
         var test = require('./fixtures/forms/singlecomponents2.js');
         helper
@@ -2814,6 +2814,42 @@ module.exports = function(app, template, hook) {
     });
 
     describe('Unique Fields', function() {
+      before('Sets up the submissions', function(done) {
+        const components = [
+            {
+              input: true,
+              label: 'Email',
+              key: 'email',
+              unique: true,
+              type: 'email'
+            },
+            {
+              input: true,
+              label: 'Text Field',
+              key: 'textField',
+              unique: true,
+              type: 'textfield',
+              validate: {
+                pattern: '[A-Za-z0-9]+'
+              }
+            }
+          ];
+        const values = {
+          email: 'brendan@form.io',
+          textField: 'I am a unique snowflake'
+        }
+        helper
+          .form('uniqueTest', components)
+          .submission(values)
+          .expect(201)
+          .execute(function(err) {
+            if (err) {
+              done(err);
+            }
+            done();
+          });
+      });
+
       it('Returns an error when non-unique', function(done) {
         var components = [
           {
@@ -2866,6 +2902,52 @@ module.exports = function(app, template, hook) {
             assert.equal(helper.lastResponse.body.details.length, 1);
             assert.equal(helper.lastResponse.body.details[0].message, 'Text Field must be unique');
             assert.deepEqual(helper.lastResponse.body.details[0].path, ['textField']);
+            done();
+          });
+      });
+
+      it('Returns an error for non-unique emails and text fields with pattern [A-Za-z0-9]+', function (done) {
+        const components = [
+        {
+          input: true,
+          label: 'Email',
+          key: 'email',
+          unique: true,
+          type: 'email'
+        },
+        {
+          input: true,
+          label: 'Text Field',
+          key: 'textField',
+          unique: true,
+          type: 'textfield',
+          validate: {
+            pattern: '[A-Za-z0-9]+'
+          }
+        }
+        ];
+        const values = {
+          email: 'brendan@form.io',
+          textField: 'I am a unique snowflake'
+        };
+
+        helper
+          .form('uniqueTest', components)
+          .submission(values)
+          .expect(400)
+          .execute(function (err) {
+            if (err) {
+              return done(err);
+            }
+
+            helper.getLastSubmission();
+            assert.equal(helper.lastResponse.statusCode, 400);
+            assert.equal(helper.lastResponse.body.name, 'ValidationError');
+            assert.equal(helper.lastResponse.body.details.length, 2);
+            assert.equal(helper.lastResponse.body.details[0].message, 'Email must be unique');
+            assert.deepEqual(helper.lastResponse.body.details[0].path, ['email']);
+            assert.equal(helper.lastResponse.body.details[1].message, 'Text Field must be unique');
+            assert.deepEqual(helper.lastResponse.body.details[1].path, ['textField']);
             done();
           });
       });


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9814

## Description

We use case insensitive regex queries to evaluate uniqueness for string-based components. Indexes on this type of query don't really do much for you, so this is potentially very slow given a large dataset. So, for things like login and registration where we have to do searches for emails over a > 1TB dataset (e.g. in our SaaS environment), we need a way to make this faster, so for email components (and text components with a certain regex pattern) - where we're pretty certain the local will be 'en' -  we leverage collation-aware searching.

However, this was incorrectly implemented in the unique validation subroutine - this PR updates the logic to use our feature detection flag to ensure we _can_ use collation-aware search before we pull the trigger on the query.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Manual and automated testing

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
