### PR TITLE
FIO-9952: fixed components paths in  CSV export

### DIFF
--- a/src/export/exporters/CSVExporter.js
+++ b/src/export/exporters/CSVExporter.js
@@ -387,9 +387,9 @@ class CSVExporter extends Exporter {
 
         items.forEach((item) => {
           const finalItem = {
-            path,
+            path: compPaths.path,
             key: component.key,
-            label: (item.label || path).replace(labelRegexp, '.'),
+            label: (item.label || compPaths.path).replace(labelRegexp, '.'),
             title: component.label,
             dataPath: compPaths.path
           };

--- a/test/export/CSVExporter/CSVExporter.js
+++ b/test/export/CSVExporter/CSVExporter.js
@@ -15,6 +15,7 @@ module.exports = function (app, template, hook) {
   const testNominatimAddress = require('../../fixtures/forms/nominatimAddressComponent');
   const testTimeDate = require('../../fixtures/forms/timeDateComponent.js');
   const wizardTest = require('../../fixtures/forms/wizardFormWithAdvancedConditions.js');
+  const formWithLayoutComponents = require('../../fixtures/forms/formWithLayoutComponents.js');
   function getComponentValue(exportedText, compKey, submissionIndex) {
     const rows = exportedText.split('\n');
     const headerRow = rows[0];
@@ -23,15 +24,15 @@ module.exports = function (app, template, hook) {
     const submissionRow = rows[submissionIndex + 1];
     const submissionRowValues = submissionRow.split(/,(?=")/);
     const compValue = submissionRowValues[compColIndex];
-    console.log({
-      rows,
-      headerRow,
-      headings,
-      compColIndex,
-      submissionRow,
-      submissionRowValues,
-      compValue
-    });
+    // console.log({
+    //   rows,
+    //   headerRow,
+    //   headings,
+    //   compColIndex,
+    //   submissionRow,
+    //   submissionRowValues,
+    //   compValue
+    // });
     return compValue;
   }
 
@@ -248,9 +249,9 @@ module.exports = function (app, template, hook) {
             if (error) {
               return done(error);
             }
-            assert.strictEqual(getComponentValue(result.text, 'page1.number', 0), '"2"');
-            assert.strictEqual(getComponentValue(result.text, 'page2.textField', 0), '"test"');
-            assert.strictEqual(getComponentValue(result.text, 'page2.textArea', 0), '"test New"');
+            assert.strictEqual(getComponentValue(result.text, 'number', 0), '"2"');
+            assert.strictEqual(getComponentValue(result.text, 'textField', 0), '"test"');
+            assert.strictEqual(getComponentValue(result.text, 'textArea', 0), '"test New"');
             done();
           });
         });
@@ -279,9 +280,47 @@ module.exports = function (app, template, hook) {
             }
 
             assert.strictEqual(helper.template.forms.panelTest.display, 'form');
-            assert.strictEqual(getComponentValue(result.text, 'page1.number', 0), '"2"');
-            assert.strictEqual(getComponentValue(result.text, 'page2.textField', 0), '"test Form"');
-            assert.strictEqual(getComponentValue(result.text, 'page2.textArea', 0), '"test Form New"');
+            assert.strictEqual(getComponentValue(result.text, 'number', 0), '"2"');
+            assert.strictEqual(getComponentValue(result.text, 'textField', 0), '"test Form"');
+            assert.strictEqual(getComponentValue(result.text, 'textArea', 0), '"test Form New"');
+            done();
+          });
+        });
+    });
+
+    it('Should correctly display paths for component inside layout components', (done) => {
+      let owner = (app.hasProjects || docker) ? template.formio.owner : template.users.admin;
+      helper = new Helper(owner);
+      helper
+        .project()
+        .form('layoutTest', formWithLayoutComponents.form.components)
+        .submission(formWithLayoutComponents.submission)
+        .execute((err) => {
+          if (err) {
+            return done(err);
+          }
+          helper.getExport(helper.template.forms.layoutTest, 'csv', (error, result) => {
+            if (error) {
+              return done(error);
+            }
+            const rows = result.text.split('\n');
+            const headerRow = rows[0];
+            const headings = headerRow.split(/,(?=")/);
+            assert.deepEqual(headings, [
+              '"_id"',
+              '"created"',
+              '"modified"',
+              '"id"',
+              '"number"',
+              '"firstName"',
+              '"lastName"',
+              '"age"',
+              '"textArea"',
+              '"email"',
+              '"phoneNumber"',
+              '"container.signature"'
+            ]);
+      
             done();
           });
         });

--- a/test/fixtures/forms/formWithLayoutComponents.js
+++ b/test/fixtures/forms/formWithLayoutComponents.js
@@ -1,0 +1,258 @@
+module.exports = {
+  form: {
+    _id: '67ebedf0848c242d2324ff9c',
+    title: 'Web',
+    name: 'web',
+    path: 'web',
+    type: 'resource',
+    display: 'form',
+    components: [
+      {
+        label: 'Columns',
+        columns: [
+          {
+            components: [
+              {
+                label: '1 - Columns: ID',
+                applyMaskOn: 'change',
+                tableView: true,
+                validateWhenHidden: false,
+                key: 'id',
+                type: 'textfield',
+                input: true,
+              },
+              {
+                label: '2 - Columns: Number',
+                applyMaskOn: 'change',
+                mask: false,
+                tableView: false,
+                delimiter: false,
+                requireDecimal: false,
+                inputFormat: 'plain',
+                truncateMultipleSpaces: false,
+                validateWhenHidden: false,
+                key: 'number',
+                type: 'number',
+                input: true,
+              },
+            ],
+            width: 6,
+            offset: 0,
+            push: 0,
+            pull: 0,
+            size: 'md',
+            currentWidth: 6,
+          },
+          {
+            components: [],
+            width: 6,
+            offset: 0,
+            push: 0,
+            pull: 0,
+            size: 'md',
+            currentWidth: 6,
+          },
+        ],
+        key: 'columns',
+        type: 'columns',
+        input: false,
+        tableView: false,
+      },
+      {
+        label: '',
+        key: 'fieldset',
+        type: 'fieldset',
+        input: false,
+        tableView: false,
+        components: [
+          {
+            label: '3 - Field Set: First Name',
+            applyMaskOn: 'change',
+            tableView: true,
+            validateWhenHidden: false,
+            key: 'firstName',
+            type: 'textfield',
+            input: true,
+          },
+        ],
+      },
+      {
+        label: 'Panel',
+        collapsible: false,
+        key: 'panel',
+        type: 'panel',
+        input: false,
+        tableView: false,
+        components: [
+          {
+            label: '4 - Panel: Last Name',
+            applyMaskOn: 'change',
+            tableView: true,
+            validateWhenHidden: false,
+            key: 'lastName',
+            type: 'textfield',
+            input: true,
+          },
+        ],
+      },
+      {
+        label: 'Table',
+        cellAlignment: 'left',
+        key: 'table',
+        type: 'table',
+        input: false,
+        tableView: false,
+        rows: [
+          [
+            {
+              components: [
+                {
+                  label: '5 - Table: Age',
+                  applyMaskOn: 'change',
+                  mask: false,
+                  tableView: true,
+                  delimiter: false,
+                  requireDecimal: false,
+                  inputFormat: 'plain',
+                  truncateMultipleSpaces: false,
+                  validateWhenHidden: false,
+                  key: 'age',
+                  type: 'number',
+                  input: true,
+                },
+                {
+                  label: '6 -Table: Text Area',
+                  applyMaskOn: 'change',
+                  autoExpand: false,
+                  tableView: true,
+                  validateWhenHidden: false,
+                  key: 'textArea',
+                  type: 'textarea',
+                  input: true,
+                },
+              ],
+            },
+            {
+              components: [],
+            },
+            {
+              components: [],
+            },
+          ],
+          [
+            {
+              components: [],
+            },
+            {
+              components: [],
+            },
+            {
+              components: [],
+            },
+          ],
+          [
+            {
+              components: [],
+            },
+            {
+              components: [],
+            },
+            {
+              components: [],
+            },
+          ],
+        ],
+      },
+      {
+        label: 'Tabs',
+        components: [
+          {
+            label: 'Tab 1',
+            key: 'tab1',
+            components: [
+              {
+                label: '7 - Tabs: Email',
+                applyMaskOn: 'change',
+                tableView: true,
+                validateWhenHidden: false,
+                key: 'email',
+                type: 'email',
+                input: true,
+              },
+            ],
+          },
+        ],
+        key: 'tabs',
+        type: 'tabs',
+        input: false,
+        tableView: false,
+      },
+      {
+        label: 'Well',
+        key: 'well',
+        type: 'well',
+        input: false,
+        tableView: false,
+        components: [
+          {
+            label: '8 - Well: Phone Number',
+            applyMaskOn: 'change',
+            tableView: true,
+            validateWhenHidden: false,
+            key: 'phoneNumber',
+            type: 'phoneNumber',
+            input: true,
+          },
+        ],
+      },
+      {
+        label: 'Container',
+        tableView: false,
+        validateWhenHidden: false,
+        key: 'container',
+        type: 'container',
+        input: true,
+        components: [
+          {
+            label: '9 - Container: Signature',
+            tableView: false,
+            validateWhenHidden: false,
+            key: 'signature',
+            type: 'signature',
+            input: true,
+            height: '200px',
+          },
+        ],
+      },
+      {
+        type: 'button',
+        label: 'Submit',
+        key: 'submit',
+        disableOnInvalid: true,
+        input: true,
+        tableView: false,
+      },
+    ],
+    machineName: 'bcmuuifnsbrkvdx:web',
+    project: '67caad5b0416ffb92916c9ad',
+    created: '2025-04-01T13:45:20.476Z',
+    modified: '2025-04-02T09:40:54.588Z',
+  },
+  submission: {
+    data: {
+      id: 'test',
+      firstName: 'test1',
+      lastName: 'test2',
+      textArea: 'test3',
+      email: 'tanya@form.io',
+      phoneNumber: '(333) 333-3333',
+      container: {
+        signature:
+          'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABLEAAADICAYAAAAX3XNOAAAAAXNSR0IArs4c6QAAIABJREFUeF7t3QuQV9WdJ/BfQzfvZzcgCsj7/ZCnvDS+YnyOZDSaZBJ3TTLW6m7YmpjspuKUVVsmlaiZIZZJNjOTaNbHRE10MAnR6GQIhJEBG1ABgQYEA6K839A8Gtk614XVhNJu/s3f292fW0X9mz/33PO7n3Ogim+de27JgQPbjoeDAAECBAgQIECAAAECBAgQIECAQI4FSoRYOR4dpREgQIAAAQIECBAgQIAAAQIECGQCQiwTgQABAgQIECBAgAABAgQIECBAIPcCQqzcD5ECCRAgQIAAAQIECBAgQIAAAQIEhFjmAAECBAgQIECAAAECBAgQIECAQO4FhFi5HyIFEiBAgAABAgQIECBAgAABAgQICLHMAQIECBAgQIAAAQIECBAgQIAAgdwLCLFyP0QKJECAAAECBAgQIECAAAECBAgQEGKZAwQIECBAgAABAgQIECBAgAABArkXEGLlfogUSIAAAQIECBAgQIAAAQIECBAgIMQyBwgQIECAAAECBAgQIECAAAECBHIvIMTK/RApkAABAgQIECBAgAABAgQIECBAQIhlDhAgQIAAAQIECBAgQIAAAQIECOReQIiV+yFSIAECBAgQIECAAAECBAgQIECAgBDLHCBAgAABAgQIECBAgAABAgQIEMi9gBAr90OkQAIECBAgQIAAAQIECBAgQIAAASGWOUCAAAECBAgQIECAAAECBAgQIJB7ASFW7odIgQQIECBAgAABAgQIECBAgAABAkIsc4AAAQIECBAgQIAAAQIECBAgQCD3AkKs3A+RAgkQIECAAAECBAgQIECAAAECBIRY5gABAgQIECBAgAABAgQIECBAgEDuBYRYuR8iBRIgQIAAAQIECBAgQIAAAQIECAixzAECBAgQIECAAAECBAgQIECAAIHcCwixcj9ECiRAgAABAgQIECBAgAABAgQIEBBimQMECBAgQIAAAQIECBAgQIAAAQK5FxBi5X6IFEiAAAECBAgQIECAAAECBAgQICDEMgcIECBAgAABAgQIECBAgAABAgRyLyDEyv0QKZAAAQIECBAgQIAAAQIECBAgQECIZQ4QIECAAAECBAgQIECAAAECBAjkXkCIlfshUiABAgQIECBAgAABAgQIECBAgIAQyxwgQIAAAQIECBAgQIAAAQIECBDIvYAQK/dDpEACBAgQIECAAAECBAgQIECAAAEhljlAgAABAgQIECBAgAABAgQIECCQewEhVu6HSIEECBAgQIAAAQIECBAgQIAAAQJCLHOAAAECBAgQIECAAAECBAgQIEAg9wJCrNwPkQIJECBAgAABAgQIECBAgAABAgSEWOYAAQIECBAgQIAAAQIECBAgQIBA7gWEWLkfIgUSIECAAAECBAgQIECAAAECBAgIscwBAgQIECBAgAABAgQIECBAgACB3AsIsXI/RAokQIAAAQIECBAgQIAAAQIECBAQYpkDBAgQIECAAAECBAgQIECAAAECuRcQYuV+iBRIgAABAgQIECBAgAABAgQIECAgxDIHCBAgQIAAAQIECBAgQIAAAQIEci8gxMr9ECmQAAECBAgQIECAAAECBAgQIEBAiGUOECBAgAABAgQIECBAgAABAgQI5F5AiJX7IVIgAQIECBAgQIAAAQIECBAgQICAEMscIECAAAECBAgQIECAAAECBAgQyL2AECv3Q6RAAgQIECBAgAABAgQIECBAgAABIZY5QIAAAQIECBAgQIAAAQIECBAgkHsBIVbuh0iBBAgQIECAAAECBAgQIECAAAECQixzgAABAgQIECBAgAABAgQIECBAIPcCQqzcD5ECCRAgQIAAAQIECBAgQIAAAQIEhFjmAAECBAgQIECAAAECBAgQIECAQO4FhFi5HyIFEiBAgAABAgQIECBAgAABAgQICLHMAQIECBAgQIAAAQIECBAgQIAAgdwLCLFyP0QKJECAAAECBAgQIECAAAECBAgQEGKZAwQIECBAgAABAgQIECBAgAABArkXEGLlfogUSIAAAQIECBAgQIAAAQIECBAgIMQyBwgQIECAAAECBAgQIECAAAECBHIvIMTK/RApkAABAgQIECBAgAABAgQIECBAQIhlDhAgQIAAAQIECBAgQIAAAQIECOReQIiV+yFSIAECBAgQIECAAAECBAgQIECAgBDLHCBAgAABAgQIECBAgAABAgQIEMi9gBAr90OkQAIECBAgQIAAAQIECBAgQIAAASGWOUCAAAECBAgQIECAAAECBAgQIJB7ASFW7odIgQQIECBAgAABAgQIECBAgAABAkIsc4AAAQIECBAgQIAAAQIECBAgQCD3AkKs3A+RAgkQIECAAAECBAgQIECAAAECBIRY5gABAgQIECBAgAABAgQIECBAgEDuBYRYuR8iBRIgQIAAAQIECBAgQIAAAQIECAixzAECBAgQIECAAAECBAgQIECAAIHcCwixcj9ECiRAgAABAgQIECBAgAABAgQIEBBimQMECBAgQIAAAQIECBAgQIAAAQK5FxBi5X6IFEiAAAECBAgQIECAAAECBAgQICDEMgcIECBAgAABAgQIECBAgAABAgRyLyDEyv0QKZAAAQIECBAgQIAAAQIECBAgQECIZQ4QIECAAAECBAgQIECAAAECBAjkXkCIlfshUiABAgQIECBAgAABAgQIECBAgIAQyxwgQIAAAQIECBAgQIAAAQIECBDIvYAQK/dDpEACBAgQIECAAAECBAgQIECAAAEhljlAgAABAgQIECBAgAABAgQIECCQewEhVu6HSIEECBAgQIAAAQIECBAgQIAAAQJCLHOAAAECBAgQIECAAAECBAgQIEAg9wJCrNwPkQIJECBAgAABAgQIECBAgAABAgSEWOYAAQIECBAgQIAAAQIECBAgQIBA7gWEWLkfIgUSIECAAAECBAgQIECAAAECBAgIscwBAgQIECBAgAABAgQIECBAgACB3AsIsXI/RAokQIAAAQIECBAgQIAAAQIECBAQYpkDBAgQIECAAAECBAgQIECAAAECuRcQYuV+iBRIgAABAgQIECBAgAABAgQIECAgxDIHCBAgQIAAAQIECBAgQIAAAQIEci8gxMr9ECmQAAECBAgQIECAAAECBAgQIEBAiGUOECBAgAABAgQIECBAgAABAgQI5F5AiJX7IVIgAQJ5E1i27LUoKSmJd955J/ts1qxZlJWVxp49e6Oyckn2c8uWLWP//gPRsWP77HPFilWxc+fOaNmyVdamZcsWWfsjR45GTc3R7PyFCxfF/v37o6amJo4erYnWrVvF0aNHs3OOHz+e/Uptjx2ryUgOHqyOVq1axqFDh08StWnTOsaOHR3Hjh3L6kpt0mezZs3j0ksvisOHD2e/b968eUydOjlrV17eKYYNG5o3ZvUQIECAAAECBAgQIEDgfQJCLBOCAIFGI7B79+5YtWpNFgKlIwU8s2fPjSNHjmThTwp00vHHP26MDRs2ZN+lo6Sk2f/7LImNGzfGunVvvM8kBUOpbfPmpVnIdOGFU05ploKiqVMnnfLPRo4cHp07d3rPn6W+363nxFFaWhaTJ59/2uORwqzKykWnbP/WW2/H2rXrsj9L4dn8+Qvj+PF3st/Pmzf/ZBjWo8c5kWpNQVf67NKlSxbKTZw4IftuwID+2bkOAgQIECBAgAABAgQIFFtAiFVscf0RIFBrgU2b3oodO3ZGdXV1tsLpnXeOZauPFi1acnJV0rx5L2ahTPo+HX8aMA0fPizKyzu/r893VyGdOmxKJ06YML5JBjXV1Ydi0aLFmVVV1ZrYsmVr7Nu3L155ZenJsCsFemVlLWLSpAnZ6rHWrVvHxInjo1OnjtlKtPRdCg0rKiqic+eOMWXK5GzVmYMAAQIECBAgQIAAAQKFCgixChXUngCBOgns3bs3duzYlbVZvPjlOHDgQOzbtz8WLFgYrVq1zlYS7dy5Ows+ysrKonfvXtm548aNjRSgpGPMmPOifft22c99+vSOXr161qkGJxcmsG3b9li1qiq2bdsRK1euir1792WPPabPN9988+TFX3vt3UcoP/OZG+P++++N9u3bF9ax1gQIECBAgAABAgQINGkBIVaTHn43T6DuAkuXLo82bdpkq6LSvk0HDx6MJUteyVbkpP2WUvCUzkmrp9Kjdym4SCufKisXZ+emNieCqf79+8U555ydFZFWRqXzevbsGX379q57YVrkUmDhwsq4/fa/icOHD8Ujj/wkxo0bk8s6FUWAAAECBAgQIECAQP4FhFj5HyMVEqhXgRQmHTp0KO0Ela2mSY/rlZY2z/pIe0Vt3PhmtvdR2i8q7Q2VHilLeyKlPaHSuRUV5TFs2JD31TRixLDo3Pn9j+ydf/57H8kryYKpnj171Ou9uFjDEHj99fVx+eXXRlrB9dhjD8a0adc2jMJVSYAAAQIECBAgQIBArgSEWLkaDsUQqLtAelNe2rQ7BVFVVWsj7SOVHsWbO3devPPO8WyFVPo5Heltd2nfowED+sXZZ3fPvkt7GKXA6cSRgqZ+/fqc/H337t1j4MD+dS9MCwLvEdi8eUtceulVWVDatm3bqKp6+c+CT2AECBAgQIAAAQIECBD4IAEhlvlBIKcCaRVUelNeixYt44UXfpc9ard69ZrYuHFTtpIqPbL33uPEhubv3SMqrX46sV/Ue/eUyuktK6uRC+zZsycmT74kC7Lmzn0+xo8f28jv2O0RIECAAAECBAgQIFCfAkKs+tR0LQK1ENiwYWNs3bote+vbyy+/mr1ZL739bdeuPdmm2GvXrsuuklZNtWzZKkaOHJb9fuzYMdG2bZvo0eOc6N+/b/bdqFEjomPHjrXo1SkE8iHwne/8XXzrW/fGww//OD71qU/moyhVECBAgAABAgQIECDQIASEWA1imBTZEARSOJXezpY2L1+4cFG2j1T6TGFV2l9qwYLKbHPrAwcOZrdzwQWTs+/79u2T7RXVqtX/f6xvwoT37ifVEO5ejQRqJ/Dkk0/FF794e9x55/+Iv/3b/1m7Rs4iQIAAAQIECBAgQIBA2tn5wIFtx0kQIPDBAunxp2XLlkfa12fXrt3ZCqq0r8+KFSvj7bc3Z2/c27lzZ/bWvXPP7RUlJc1i8uTzs0cA0ybpU6ZMzD6tnDLTmrpAWnU4deplccklF8WsWU81dQ73T4AAAQIECBAgQIBAHQSEWHXAcmrjFUj7T+3YsSMWL3459u/fH0uWvBrV1dVZWJUCqt27d0facyq9gS+9iS+toEohVWlpabZxur19Gu/ccGf1K3D48JHo3r1vdOrUMdavX1G/F3c1AgQIECBAgAABAgQatYAQq1EPr5s7IbB//4GorFwUpaVl2Zv6KisXx5EjR+P119dl4dWhQ4ezUzt16hSjR4+KiRPT43ytYtKkCVloVV5eDpMAgXoS6N69X/aY7c6dm7I3aToIECBAgAABAgQIECBQGwEhVm2UnJN7gZdeWhQbNryZvc0vrapKqz2qqlZnP6fH/P70SKuqTrzFb8KEcdGxY4eYOHFC7u9TgQQausCJPbHSqsaNG6uyVY0OAgQIECBAgAABAgQI1EZAiFUbJed85AKbNr0VL7zwb7Ft2/Zsb6r0mQKq9P2pjoqK8hg2bMjJoGrIkMHRrVuXGDp0SHTpUvGR348CCDRFgb1798aoUROzv7+33PL5+OEPv9cUGdwzAQIECBAgQIAAAQKnKSDEOk04zepfIG2S/uKLC+LVV5fFzp27Iq2uOnr0aGzfvuOUnXXvflYMHNg/TrzJL62oat++fbZXlYMAgfwJfPWr34h/+IefRMeOHWPBgt9nL0FwECBAgAABAgQIECBAoLYCQqzaSjmv3gRmz54TK1euzt7st2zZa9mqjA0bNp7y+mnVVFo9lTZOb9++XbZXVdeuXWP48KH1Vo8LESBw5gXmz18Y11xzfRw5ciS+9KX/HA888HdnvlM9ECBAgAABAgQIECDQqASEWI1qOPN1M2klVQqo0uqq5ctXxJtvbsr2qfrT492ganCMGjUiW6Fx3nkj45xzzo6xY0fn64ZUQ4DAaQmkfenGjbswtm7dGt26dY1nn/2XLJx2ECBAgAABAgQIECBAoC4CQqy6aDn3lAJbt26Lqqo1MWfOH7JH/1J4tXTp8lOeO2XKxCyk6tevX4wcOSwGDOgfZ5/dnSwBAo1Y4Ctf+Xr80z89lN3hlVd+PJ5++vFGfLdujQABAgQIECBAgACBMyUgxDpTso30uhs3vhl/+MO/x65de6KyclG89NLi2L59exw8WH3yjtO+VKNHj4yBAwdEr1494/zzx0X//v2ynx0ECDQtgUcffTxuu+2/n7zp2bOf9SbQpjUF3C0BAgQIECBAgACBehMQYtUbZeO60OLFL0d19aGorFwcK1dWxapVVZG++9OjX78+MWLE8Bg3bnSkjdXTZuuDBw9qXBjuhgCB0xKYNeu5+Nznvhg1NTVZ+x/8YEZ84Qs3n9a1NCJAgAABAgQIECBAgIAQqwnOgaeeeiYOHz4Ur7yyNEpKSmLp0teiuro60mOBaYP1Dh06xN69e/9MJm2uPmjQwBg6dFC20frYsWOiXbu2TVDQLRMg8GEC69a9EZdddnX270rz5s3j5ps/GzNm3BstW7b4sKb+nAABAgQIECBAgAABAqcUEGI10omRVlC99trKWLRoSbZP1a9//Wyt7rRNm9bZhupt27bNPtPKqkmTzo8RI4bVqr2TCBAgcPTo0Zg27dMxd+68DCO9tGHevH+N0tJSOAQIECBAgAABAgQIEDhtASHWadPlp2HaSP25516I9evfiFdfXR6rV6/50OLSBusVFRUxcuTw7FeXLl0ifecgQIBAoQJ33fXNmDHjgewyXbt2ieeem+lthIWiak+AAAECBAgQIECAQAixGtgk+MUvZsbBgwfjt7/915g/f0G2yuqDjrRP1dSpk6NDh/YxefL52eqqdu3aNbC7Vi4BAg1F4PnnfxfXX//Zk+X+9Kf/GDfddH1DKV+dBAgQIECAAAECBAjkWECIldPBSXtTLVhQGfPmvZjtU/W73/3+Qyu94ILJMXnyxOjbt09MnDg+hgwZ/KFtnECAAIH6EkhvL73ooitiy5at2SWnT78t7rnnm/V1edchQIAAAQIECBAgQKCJCwixPuIJsGLFynjrrc3Zf/rWrn09XnppcfYWwH379n1gZWmPmQED+sW4cWNiwoTxMXXqpI/4TnRPgEBTFtizZ09ccsnVUVW1OmP42McuiGeeedJG7k15Urh3AgQIECBAgAABAvUsIMSqZ9BTXS795+7xx38Rhw8fjqqqNbFu3frYsmVbvP76ujh27NgHVlBRUR7Dhg3JNla/4IKp0bPnOdmbAR0ECBDIk8Bf//V/i8cf/3lW0sCB/ePJJx+JwYMH5alEtRAgQIAAAQIECBAg0MAFhFj1PIDV1Yfin//5iXjxxf+Il19eGmvWrK11D+k/fH379s72rUorrNKvtCmygwABAnkVOHTocNx22/RI+/Wlo2XLFjFz5hNx0UUX5rVkdREgQIAAAQIECBAg0EAFhFj1MHAHDhyMmTN/FQ8++HCkNwXW9mjRokXceOP18Rd/cVV84hMf99hNbeGcR4BALgTSv3133PH1eOyxJ04GWD/72f+JK6+8PBf1KYIAAQIECBAgQIAAgcYlIMQ6zfHcvHlLpLdwpbcEPvvs81FTU1OrK3Xq1CmuvfbKuOyyi+O6666NVq1a1qqdkwgQIJAngfRv4Kc//Z9i0aIlWVnl5eVx//33xQ03TMtTmWohQIAAAQIECBAgQKARCQix6jiYTz/9y3jsscdjzpx5ceTIkVq17ty5c3zyk9fG1VdfEZdffmmUlZXVqp2TCBAgkEeB5ctXxC23/JdYuXJVVt655/aKWbOejv79++axXDURIECAAAECBAgQINBIBIRYtRjItDH7E088Fd///o9i/fo/1qJFRHpUcNq0a7LVVumzefPmtWrnJAIECORZ4Je/nBW33/43kf5dTMdVV30ivv3t/xWDBg3Mc9lqI0CAAAECBAgQIECgEQgIsT5kEO+9d0bcc8/f12rVVfv27ePiiy/MHhW88ca/jPTooIMAAQKNQSA9Mv2Vr3w9HnrokZO3M336bXHXXd+Itm3bNIZbdA8ECBAgQIAAAQIECORcQIj1AQOU/tPWp8+w2LVr1wcO46WXvhtapccFu3SpyPmQK48AAQJ1E9i/f3/ceuuX41e/+k3WMAX2Dzzw3bjpphvqdiFnEyBAgAABAgQIECBAoAABIdZphlgprLr99lvj1lu/EBUV5QUMgaYECBDIr8Dbb2+OSy65KjZufDMrcsqUifHTn/5j9OzZI79Fq4wAAQIECBAgQIAAgUYpIMT6kGG9665vxowZD2RnpTcJfuYzN8Ytt3w+xo8fGyUlJY1yUrgpAgQIJIHf/Oa38aUv/dfYt29fBpJWXt1337eia9cugAgQIECAAAECBAgQIFB0ASFWLciXLXstXnllaVx//TR7v9TCyykECDR8gSee+EV8+ct3RHX1oexmvvGNr2W/vKSi4Y+tOyBAgAABAgQIECDQUAWEWA115NRNgACBMyRw993fifRSi3SkFag///mjcdlll5yh3lyWAAECBAgQIECAAAECtRMQYtXOyVkECBBo9AJbtmyNO+74ejzzzKzsXtO+Vz/60f2RXl7RmI6tW7fFnDnzslVlpaXNo3Xr1tGsWbMYP36Mt8o2poF2LwQIECBAgAABAo1OQIjV6IbUDREgQKDuAumR6Ztuujk2bXorazx27Oh44omHo0ePc+p+sSK3qKxcHHPnzotu3brFsmXLY/78hdG797mxYsXKWLPm9VpXM2LEsFi4cG6tz3ciAQIECBAgQIAAAQLFFRBiFddbbwQIEMidwPe+9/24++574siRI9mKpOnTb4877/xatGvX7ozVeujQ4Xj00Z/FG29siBYtymL//v2xadPb0axZSZx11llZGLV7956oqTmWrZbq0KF9bNu2PdauXVcvNXXs2DFGjRr+vmtdc81VMX36bfVyfRchQIAAAQIECBAgQKD+BYRY9W/qigQIEGgQArt37842b58589dZvW3btonvfvfbcfPNn83CrEKOY8eOxezZc2PVqtVRWbkoVq9eG+klGWfySG9NHDJkUNZFWlXVuXPn7LO8vHP23bBhQ6OiovxMluDaBAgQIECAAAECBAicQQEh1hnEdWkCBAjkVeDpp38Z06d/Nfbs2ZOVOG7cmPjBD2bEqFEj6lTy229vjtmz58Rbb22OV19dGnv27Ivt27fH0qXL63SdEyd369Y1Bg8emIVNKXRKq8FGjhweZWWlf3a97t27x8CB/U+rH40IECBAgAABAgQIEGh4AkKshjdmKiZAgMBpC6xf/8f4q7+65WTIVFJSEldffUX85Cc/jA4dOnzgdRcvfjnbM+u5516I55//t9ixY0fU1NTUqZZ3V0h1ivHjx0VFRecYPXpUlJaWRs+ePaNv3951upaTCRAgQIAAAQIECBBoWgJCrKY13u6WAIEmKnD8+PG4++7vxH33fe+kQAqTHnvswbj44o+d/C69oTDtkZU2ek97UqXHAY8ePVontXPP7RW9e/eKPn16x5gx52Urqs47b8SHhmR16sTJBAgQIECAAAECBAg0OQEhVpMbcjdMgEBTEjh4sDruvXdGPPjgw7Fr167s1svKyuLyyy+NH//4f8eCBQvj97+fG3PmzIvly1fUiaZVq1Zx2WUXx3nnjYyzzuqWfU6YMK5O13AyAQIECBAgQIAAAQIEaisgxKqtlPMIECDQwATSxu3Tpn06Fi1acrLy6667Jm64YVrMmvVczJ3777F167Za31Xa7D09/peuMW3aNTFo0MBat3UiAQIECBAgQIAAAQIEChUQYhUqqD0BAgRyKPDUUzPja1+7M7Zt255V169fn+jVq2e89NLiqK6urlXFzZs3j+HDh0Z6PPC6666Oq676RJSXe7tfrfCcRIAAAQIECBAgQIBAvQsIseqd1AUJECDw0Qo8++zzceONn69zEZ06dcreTjhx4vgYNGhATJ48yWbrdVbUgAABAgQIECBAgACBMyUgxDpTsq5LgACBj0hg+vSvxkMPPfKhvbdr1zauuOLj2ZsCx40bE5MmTYi0+spBgAABAgQIECBAgACBPAoIsfI4KmoiQIBAgQKf+tTnYu3a12Pnzt2xY8eO7GpDhw6OadOujRYtyqJHj3Pihhv+Mlq3blVgT5oTIECAAAECBAgQIECgOAJCrOI464UAAQIECBAgQIAAAQIECBAgQKAAASFWAXiaEiBAgAABAgQIECBAgAABAgQIFEdAiFUcZ70QIECAAAECBAgQIECAAAECBAgUICDEKgBPUwIECBAgQIAAAQIECBAgQIAAgeIICLGK46wXAgQIECBAgAABAgQIECBAgACBAgSEWAXgaUqAAAECBAgQIECAAAECBAgQIFAcASFWcZz1QoAAAQIECBAgQIAAAQIECBAgUICAEKsAPE0JECBAgAABAgQIECBAgAABAgSKIyDEKo6zXggQIECAAAECBAgQIECAAAECBAoQEGIVgKcpAQIECBAgQIAAAQIECBAgQIBAcQSEWMVx1gsBAgQIECBAgAABAgQIECBAgEABAkKsAvA0JUCAAAECBAgQIECAAAECBAgQKI6AEKs4znohQIAAAQIECBAgQIAAAQIECBAoQECIVQCepgQIECBAgAABAgQIECBAgAABAsUREGIVx1kvBAgQIECAAAECBAgQIECAAAECBQgIsQrA05QAAQIECBAgQIAAAQIECBAgQKA4AkKs4jjrhQABAgQIECBAgAABAgQIECBAoAABIVYBeJoSIECAAAECBAgQIECAAAECBAgUR0CIVRxnvRAgQIAAAQIECBAgQIAAAQIECBQgIMQqAE9TAgQIECBAgABPlZ3eAAADmklEQVQBAgQIECBAgACB4ggIsYrjrBcCBAgQIECAAAECBAgQIECAAIECBIRYBeBpSoAAAQIECBAgQIAAAQIECBAgUBwBIVZxnPVCgAABAgQIECBAgAABAgQIECBQgIAQqwA8TQkQIECAAAECBAgQIECAAAECBIojIMQqjrNeCBAgQIAAAQIECBAgQIAAAQIEChAQYhWApykBAgQIECBAgAABAgQIECBAgEBxBIRYxXHWCwECBAgQIECAAAECBAgQIECAQAECQqwC8DQlQIAAAQIECBAgQIAAAQIECBAojoAQqzjOeiFAgAABAgQIECBAgAABAgQIEChAQIhVAJ6mBAgQIECAAAECBAgQIECAAAECxREQYhXHWS8ECBAgQIAAAQIECBAgQIAAAQIFCAixCsDTlAABAgQIECBAgAABAgQIECBAoDgCQqziOOuFAAECBAgQIECAAAECBAgQIECgAAEhVgF4mhIgQIAAAQIECBAgQIAAAQIECBRHQIhVHGe9ECBAgAABAgQIECBAgAABAgQIFCAgxCoAT1MCBAgQIECAAAECBAgQIECAAIHiCAixiuOsFwIECBAgQIAAAQIECBAgQIAAgQIEhFgF4GlKgAABAgQIECBAgAABAgQIECBQHAEhVnGc9UKAAAECBAgQIECAAAECBAgQIFCAgBCrADxNCRAgQIAAAQIECBAgQIAAAQIEiiMgxCqOs14IECBAgAABAgQIECBAgAABAgQKEBBiFYCnKQECBAgQIECAAAECBAgQIECAQHEEhFjFcdYLAQIECBAgQIAAAQIECBAgQIBAAQJCrALwNCVAgAABAgQIECBAgAABAgQIECiOgBCrOM56IUCAAAECBAgQIECAAAECBAgQKEBAiFUAnqYECBAgQIAAAQIECBAgQIAAAQLFERBiFcdZLwQIECBAgAABAgQIECBAgAABAgUICLEKwNOUAAECBAgQIECAAAECBAgQIECgOAJCrOI464UAAQIECBAgQIAAAQIECBAgQKAAASFWAXiaEiBAgAABAgQIECBAgAABAgQIFEdAiFUcZ70QIECAAAECBAgQIECAAAECBAgUICDEKgBPUwIECBAgQIAAAQIECBAgQIAAgeIICLGK46wXAgQIECBAgAABAgQIECBAgACBAgSEWAXgaUqAAAECBAgQIECAAAECBAgQIFAcASFWcZz1QoAAAQIECBAgQIAAAQIECBAgUIDA/wWXgZzhKm6BCgAAAABJRU5ErkJggg==',
+      },
+      submit: true,
+      number: 123,
+      age: 23,
+    },
+  },
+};


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9952

## Description

**What changed?**

The changed eachComponent returns the full component path that includes layout components. But the CSV export expects the value path (as it was in 4.x.) so that CSV import works fine. This PR fixes it.

## How has this PR been tested?

Manually + autotests

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
