### PR TITLE
FIO-9943: fix save submission action on Open Source Portal

### DIFF
--- a/portal/src/components/FormView/FormActions.tsx
+++ b/portal/src/components/FormView/FormActions.tsx
@@ -7,6 +7,7 @@ import {
   FormProps,
 } from '@formio/react';
 import { Component, ButtonComponent } from '@formio/core';
+import { Utils } from '@formio/js';
 import { useCallback, useState, useRef, useEffect } from 'react';
 
 export type FormAction = {
@@ -98,11 +99,39 @@ export const FormActions = ({ formId, limit }: { formId: string; limit?: number 
   const handleAddAction = async (action: FormAction) => {
     try {
       const actionInfo = await getActionInfo(formId, action.name, token);
+      // check for presence of not hidden handler and method components
+      let hasHandlerField = false;
+      let hasMethodField = false;
+      Utils.eachComponent(
+        actionInfo.settingsForm.components,
+        (component: any, path: any) => {
+          if (component.key === 'handler' && component.type !== 'hidden') {
+            hasHandlerField = true;
+          }
+          if (component.key === 'method' && component.type !== 'hidden') {
+            hasMethodField = true;
+          }
+        },
+        true,
+      );
+
+      const submissionData = {
+        ...action,
+      };
+
+      // if handler and method are not present in he form, set to defaults
+      const defaults = actionInfo?.defaults;
+      if (!hasHandlerField && defaults?.handler) {
+        submissionData.handler = defaults.handler;
+      }
+      if (!hasMethodField && defaults?.method) {
+        submissionData.method = defaults.method;
+      }
       setActiveAction({
         form: actionInfo.settingsForm,
         title: actionInfo.title,
         submission: {
-          data: action,
+          data: submissionData,
         },
         action: 'Add',
       });

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -838,6 +838,14 @@ module.exports = (router) => {
       // Set the form on the request body.
       req.body.form = req.params.formId;
 
+      // sets a default value in actions where manual input of this data is not expected (e.g. Save Submission).
+      if (!req.body.hasOwnProperty('handler') && req.body.defaults?.handler) {
+        req.body.handler = req.body.defaults.handler;
+      }
+      if (!req.body.hasOwnProperty('method') && req.body.defaults?.method) {
+        req.body.method = req.body.defaults.method;
+      }
+
       // Make sure to store handler to lowercase.
       if (req.body.handler) {
         _.each(req.body.handler, (handler, index) => {

--- a/test/actions.js
+++ b/test/actions.js
@@ -12,6 +12,7 @@ const testMappingDataForm = require('./fixtures/forms/testMappingDataForm');
 const customSaveSubmissionTransformForm = require('./fixtures/forms/customSaveSubmissionTransformForm');
 const customSaveSubmissionTransformResource = require('./fixtures/forms/customSaveSubmissionTransformResource');
 const { wait } = require('./util');
+const helper = require('./helper');
 const docker = process.env.DOCKER;
 
 module.exports = (app, template, hook) => {
@@ -375,6 +376,58 @@ module.exports = (app, template, hook) => {
           .end(done);
       });
     });
+
+    describe('Action with missing fields creation', () => {
+
+      it('Should add Save action and apply defaults for handler and method if fields are missing', async () => {      
+        const action = {
+          name: 'save',
+          title: 'Save Submission',
+          priority: 10,
+          form: tempForm._id,
+          machineName: 'saveActionFormSave',
+          settings: {},
+          defaults: {
+            handler: ['before'],
+            method: ['create', 'update']
+          }
+        };
+      
+        const response = await request(app)
+          .post(hook.alter('url', `/form/${tempForm._id}/action`, template))
+          .set('x-jwt-token',  template.users.admin.token)
+          .send({ data: action });
+      
+        assert.equal(response.status, 201);
+        assert.deepEqual(response.body.handler, ['before'], 'Default handler should be applied');
+        assert.deepEqual(response.body.method, ['create', 'update'], 'Default method should be applied');
+      });
+      
+      it('Should add Webhook action and do not apply defaults for handler and method (fields are set)', async () => {      
+        const action = {
+          name: 'webhook',
+          title: 'Webhook Action',
+          priority: 5,
+          form: tempForm._id,
+          machineName: 'webhookActionForm',
+          handler: [],
+          method: [],
+          defaults: {
+            handler: ['after'],
+            method: ['create'],
+          },
+        };
+      
+        const response = await request(app)
+          .post(hook.alter('url', `/form/${tempForm._id}/action`, template))
+          .set('x-jwt-token',  template.users.admin.token)
+          .send({ data: action });
+      
+        assert.equal(response.status, 201);
+        assert.deepEqual(response.body.handler, [], 'Handler should remain empty');
+        assert.deepEqual(response.body.method, [], 'Method should remain empty');
+      });
+    })
 
     describe('Test action with custom transform mapping data', () => {
       const addFormFields = (isForm) => ({


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9943

## Description

On the client side: a check has been added to determine whether method and handler can be entered in the form. If this is not provided for current type of action, default values are set.

On the server side, a check has been added for missed  method and handler data, and default values are set.

## Breaking Changes / Backwards Compatibility
-

## Dependencies
-

## How has this PR been tested?
manually
autotests

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
