### PR TITLE
FIO-9905: Wrong behavior signature submitted data

### DIFF
--- a/src/actions/fields/signature.js
+++ b/src/actions/fields/signature.js
@@ -38,8 +38,9 @@ module.exports = (formio) => async (component, data, handler, action, {validatio
         if (!submission) {
           throw new Error('No submission found.');
         }
-
-        _.set(data, component.key, _.get(submission.data, path));
+        if (!_.isNil(value)) {
+          _.set(data, component.key, _.get(submission.data, path));
+        }
       }
   }
 };

--- a/test/fixtures/forms/singleComponents4.js
+++ b/test/fixtures/forms/singleComponents4.js
@@ -1,0 +1,37 @@
+
+module.exports = {
+  components: [
+    {
+      label: "Text Field",
+      applyMaskOn: "change",
+      tableView: true,
+      validateWhenHidden: false,
+      key: "textField",
+      type: "textfield",
+      input: true
+    },
+    {
+      label: "Signature",
+      tableView: true,
+      validateWhenHidden: false,
+      key: "signature",
+      conditional: {
+        show: false,
+        conjunction: "all",
+        conditions: [
+          {
+            component: "textField",
+            operator: "isEmpty"
+          }
+        ]
+      },
+      type: "signature",
+      input: true
+    }
+
+  ],
+  submission: {
+    signature: "",
+    textField: "1"
+  }
+}

--- a/test/submission.js
+++ b/test/submission.js
@@ -99,6 +99,31 @@ module.exports = function(app, template, hook) {
         });
       });
 
+      var signatureSubmission2 = null;
+      it('Create submission with empty signature', function(done) {
+        var test = _.cloneDeep(require('./fixtures/forms/singleComponents4.js'));
+        helper
+          .form('test', test.components)
+          .submission(test.submission)
+          .execute(function(err) {
+            if (err) {
+              return done(err);
+            }
+            signatureSubmission2 = helper.getLastSubmission();
+            assert.deepEqual(test.submission, signatureSubmission2.data);
+            done();
+          });
+      });
+
+      it('Should not to add emtpy signature value in response if we do not put it in submission data', function(done) {
+        var updateSub = _.cloneDeep(signatureSubmission2);
+        delete updateSub.data.signature;
+        helper.updateSubmission(updateSub, function(err, updated) {
+          assert.deepEqual(updateSub.data, updated.data);
+          done();
+        });
+      });
+
       var signatureSubmission = null;
       it('Saves values with required signature', function(done) {
         var test = _.cloneDeep(require('./fixtures/forms/singlecomponents3.js'));


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9905

## Description
In the case of **beforePut** in signature, when we did not pass any signature field from UI, we automatically added it from the previous submission. I added a check for **isNil** to eliminate this behavior.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

I added unit test

## Checklist:

- [X] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings
- [X] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [X] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
