### PR TITLE
FIO-9676: Fixes foot height in the OS portal

### DIFF
--- a/portal/public/style.css
+++ b/portal/public/style.css
@@ -1900,24 +1900,17 @@ button.togglecontext {
 
 /* Footer */
 .panel-footer {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
     height: 200px;
 }
 
 /* Panels */
 
 .panels {
-    position: fixed;
-    top: 45px;
-    left: 15px;
-    bottom: 215px;
-    right: 15px;
+    height: 90vh;
+    margin-top: 85px;
+    margin-bottom: 85px;
     overflow: hidden;
     max-width: 3390px;
-    margin: 0 auto;
 }
 
 .panel-wrap {
@@ -1925,6 +1918,8 @@ button.togglecontext {
     top: 0;
     left: 0;
     bottom: 0;
+    margin-left: 15px;
+    margin-right: 15px;
 }
 .panel-header {
     position: absolute;
@@ -4876,7 +4871,7 @@ input.notop {
         border-right: 0;
     }
     .panel-footer {
-        display: none; 
+        display: none;
     }
 }
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9676

## Description

Footer was taking too much space on the screen, made it go down a bit a make the builder take all the space available 

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
