### PR TITLE
FIO-9841: remove pipes from countQuery pipeline

### DIFF
--- a/src/actions/properties/reference.js
+++ b/src/actions/properties/reference.js
@@ -329,7 +329,9 @@ module.exports = (router) => {
         return buildPipeline(component, path, req, res).then((subpipe) => {
           let pipeline = req.modelQuery.pipeline || [];
           pipeline = pipeline.concat(subpipe);
-          req.countQuery.pipeline = req.modelQuery.pipeline = pipeline;
+          req.modelQuery.pipeline = pipeline;
+          // The pipeline for references is not needed to get the count of documents
+          req.countQuery.pipeline = req.countQuery.pipeline || [];
         });
       case 'afterIndex': {
         const form = await router.formio.cache.loadForm(req, null, formId);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9841

## Description

**What changed?**

Removed reference pipes from countQuery.pipline

**Why have you chosen this solution?**

The pipes needed for saveAsReference are not needed to count the number of documents. Removed to optimize performance

## Breaking Changes / Backwards Compatibility

N/A

## Dependencies

N/A

## How has this PR been tested?

manually

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
