### PR TITLE
FIO-10043: automatically adding indexes for CosmosDB

### DIFF
--- a/src/db/index.js
+++ b/src/db/index.js
@@ -304,6 +304,29 @@ module.exports = function(formio) {
         formio.util.log('Compound indexes that contain nested paths are not supported.');
         config.mongoFeatures.compoundIndexWithNestedPath = formio.mongoFeatures.compoundIndexWithNestedPath = false;
       }
+
+      // check CosmosDB indexes
+      try {
+        // Checking whether indexes need to be created for CosmosDB to function
+        await featuresTest.dropIndexes();
+        await featuresTest.insertOne({title: 'Test Title', nested: {test: 'value'}});
+        await featuresTest.find().sort({title: 1}).limit(1).toArray();
+      }
+      catch (err) {
+        // Create indexes if they don't exist
+        const collections = await db.listCollections().toArray();
+
+        for (const {name} of collections) {
+          const collection = db.collection(name);
+          const indexes = await collection.indexes();
+
+          const hasWildcard = indexes.some(idx => idx.key && idx.key["$**"] === 1);
+
+          if (!hasWildcard) {
+            await collection.createIndex({"$**": 1});
+          }
+        }
+      }
       await featuresTest.drop();
     }
     catch (err) {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10043

## Description

**What changed?**
Added indexes ({"$**": 1}) to ensure support for sorting on arbitrary fields in CosmosDB for situations where it is necessary.

## Breaking Changes / Backwards Compatibility
-

## Dependencies
-

## How has this PR been tested?
manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
