### PR TITLE
FIO-9783: add prepare step instead of postinstall (4.5.x)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,5 +193,6 @@ jobs:
 
       - name: Publish to npm
         run: |
+          yarn
           npm version $NEW_VERSION
           yarn publish --tag dev

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:vm": "webpack --config src/vm/webpack.vm.config.js",
     "build:portal": "cd portal && yarn && yarn build && cd ..",
     "show-coverage": "open coverage/lcov-report/index.html",
-    "postinstall": "npm run build:vm"
+    "prepare": "npm run build:vm"
   },
   "author": "support@form.io",
   "engines": {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9783

## Description

Replace `postinstall` with `prepare` so that webpack is not run when library is installed as a dependency. 