### PR TITLE
FIO-10212: escape regex in unique machine name query

### DIFF
--- a/src/util/util.js
+++ b/src/util/util.js
@@ -676,7 +676,7 @@ const Utils = {
    */
   async uniqueMachineName(document, model, next) {
     var query = {
-      machineName: {$regex: `^${document.machineName}[0-9]*$`},
+      machineName: {$regex: `^${_.escapeRegExp(document.machineName)}[0-9]*$`},
       deleted: {$eq: null}
     };
     if (document._id) {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10212

## Description

In fixing a teams issue, I identified another place in which regex was not being escaped.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
