### PR TITLE
FIO-10236: Fixes an issue where Value component does not change type in the Action Conditions form

### DIFF
--- a/src/util/conditionOperators/index.js
+++ b/src/util/conditionOperators/index.js
@@ -246,7 +246,7 @@ const getValueComponentsForEachFormComponent = (flattenedComponents) => {
   Object.keys(flattenedComponents).forEach((path) => {
     const componentSchema = flattenedComponents[path];
     const component = componentSchema && componentSchema.type
-      ? {}
+      ? Formio.AllComponents[componentSchema.type]
       : null;
     const getValueComponent = component && component.serverConditionSettings ?
       component.serverConditionSettings.valueComponent :


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10236

## Description

The change with removing Formio.AllComponents usage was left by accedent wich caused an issue where Value component would not change its type/settings after choosing a component inside 'When' field in the Action Conditions form.

## How has this PR been tested?

manually tested Action Conditions form

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
