### PR TITLE
FIO-10237: update IsolateVMEvaluator to leverage hook system for Enterprise features

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,10 +62,6 @@ module.exports = function(config) {
     }
   };
 
-  // Configure the evaluator
-  const evaluator = new IsolateVMEvaluator({timeoutMs: config.vmTimeout});
-  registerEvaluator(evaluator);
-
   /**
    * Initialize the formio server.
    */
@@ -83,7 +79,7 @@ module.exports = function(config) {
             }
           }
         }
- catch (error) {
+        catch (error) {
           console.log(error);
         }
 
@@ -310,6 +306,12 @@ module.exports = function(config) {
         await connectToMongoDB();
     }
 
+    function configureEvaluator() {
+        // Configure the evaluator
+        const evaluator = new IsolateVMEvaluator({timeoutMs: config.vmTimeout}, router.formio.hook);
+        registerEvaluator(evaluator);
+    }
+
     // Hooks system during boot.
     router.formio.hooks = hooks;
 
@@ -336,6 +338,7 @@ module.exports = function(config) {
 
     setupMemoryLeakPrevention();
     setupMiddlewares();
+    configureEvaluator();
     await setupMongoDBConnection();
 
     return router.formio;

--- a/src/vm/index.js
+++ b/src/vm/index.js
@@ -72,7 +72,7 @@ class IsolateVMEvaluator extends DefaultEvaluator {
         `;
       }
 
-      this.hook.alter('dynamicVmDependencies', modifyEnv, context?.form);
+      modifyEnv = this.hook.alter('dynamicVmDependencies', modifyEnv, context?.form);
 
       try {
         if (this.noeval || options.noeval) {

--- a/src/vm/index.js
+++ b/src/vm/index.js
@@ -16,9 +16,15 @@ const CORE_LODASH_MOMENT_INPUTMASK_NUNJUCKS = fs.readFileSync(
 );
 
 class IsolateVMEvaluator extends DefaultEvaluator {
-  constructor(options) {
+  /**
+   * Create a new IsolateVMEvaluator instance
+   * @param {import('@formio/core').EvaluatorOptions} options - Evaluator options
+   * @param {*} hook - The Form.io hook system (needed for Enterprise features)
+   */
+  constructor(options, hook) {
     super(options);
     this.vm = new IsolateVM({env: CORE_LODASH_MOMENT_INPUTMASK});
+    this.hook = hook;
   }
 
   evaluate(func, args, ret, interpolate, context, options) {
@@ -40,7 +46,7 @@ class IsolateVMEvaluator extends DefaultEvaluator {
         func = this.interpolate(func, args, {...options, noeval: true});
       }
 
-            // We have to compile the InstanceShims as a part of evaluation, since they contain functions and setters & getters (@formio/vm
+      // We have to compile the InstanceShims as a part of evaluation, since they contain functions and setters & getters (@formio/vm
       // uses the structured clone algorithm to serialize into the sandbox, which means no functions and no setters/getters). To do this,
       // we filter out the instance variable that might be in the context and compile it is a part of the sandboxes' `env`
       let filteredArgs = args;
@@ -57,12 +63,16 @@ class IsolateVMEvaluator extends DefaultEvaluator {
 
       // Update the env to account for form modules
       if (options.formModule) {
-        modifyEnv += `const module = ${options.formModule};
-              if (module.options?.form?.evalContext) {
-                const evalContext = module.options.form.evalContext;
-                Object.keys(evalContext).forEach((key) => globalThis[key] = evalContext[key]);
-              }`;
+        modifyEnv += `
+          const module = ${options.formModule};
+          if (module.options?.form?.evalContext) {
+            const evalContext = module.options.form.evalContext;
+            Object.keys(evalContext).forEach((key) => globalThis[key] = evalContext[key]);
+          }
+        `;
       }
+
+      this.hook.alter('dynamicVmDependencies', modifyEnv, context.form);
 
       try {
         if (this.noeval || options.noeval) {

--- a/src/vm/index.js
+++ b/src/vm/index.js
@@ -72,7 +72,7 @@ class IsolateVMEvaluator extends DefaultEvaluator {
         `;
       }
 
-      this.hook.alter('dynamicVmDependencies', modifyEnv, context.form);
+      this.hook.alter('dynamicVmDependencies', modifyEnv, context?.form);
 
       try {
         if (this.noeval || options.noeval) {


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10237

## Description

We have the need to dynamically inject enterprise features into the VM sandbox (because e.g. our Reporting UI feature introduces some globals that we need). The new VM paradigm - in which we execute evaluations on demand rather than relying on the VM to execute the entire form orchestration process - means that we need Enterprise Server to tell us when we should inject this dependency. This PR introduces the ability for the `IsolateVMEvaluator` to call our hook system so that the Enterprise features can be injected if applicable.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

I've added automated tests.

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
