### PR TITLE
FIO-10052: sync monorepo change re: selectboxes component

### DIFF
--- a/src/util/util.js
+++ b/src/util/util.js
@@ -900,6 +900,12 @@ const Utils = {
             if (Number(value) || value === "0") {
               return Number(value);
             }
+            return value;
+          }
+          case 'selectboxes': {
+            if (['true', 'false'].includes(value)) {
+              return value !== 'false';
+            }
           }
         }
       }


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10052

Updates the coeerceQueryTypes function to account for the fact that `getComponent` called with a selectboxes component's value (e.g. `getComponent(`mySelectBoxes.mySelectBoxesValue`) will return the selectboxes component (see [@formio/core#253](https://github.com/formio/core/pull/253))

Completes the solution provided in [formio-monorepo#132](https://github.com/formio/formio-monorepo/pull/132) while we're syncing over to the monorepo