### PR TITLE
FIO-10232: update email rendering to show the timezone of an email in the timezone of the submission

### DIFF
--- a/src/util/email/utils.js
+++ b/src/util/email/utils.js
@@ -178,14 +178,14 @@ return '';
         : locationTimezone && displayInTimezone === 'location'
           ? locationTimezone
           : // of viewer (i.e. wherever this server is)
-            currentTimezone();
+            userProvidedTimezone || currentTimezone();
   return momentDate(value, format, timezone).format(format);
 };
 
 const formatTime = (component, value) => {
   if (!value) {
-return '';
-}
+    return '';
+  }
   const format = component.format ?? 'HH:mm';
   const dataFormat = component.dataFormat ?? 'HH:mm:ss';
   return moment(value, dataFormat).format(format);


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10232

## Description

When a form user submits a form using the Email action, the email rendering process will default to the timezone of the "viewer," which in this case is the server rendering the email. Oftentimes, these servers are configured to operate in UTC. We previously [made a change](https://github.com/formio/formio.js/pull/6011) that indicates to me that the desired output of the server is to display the timezone of the submission in the email.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Automated tests.

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
