### PR TITLE
4.5.x - FIO-10478: fixed an issue where emails are not sent for forms for select component

### DIFF
--- a/src/util/email/utils.js
+++ b/src/util/email/utils.js
@@ -493,6 +493,10 @@ const formioComponents = [
   'resourcefields',
 ];
 
+const cleanLabelTemplate = (template) => {
+  return (template || '').replace(/<\/?[^>]+(>|$)/g, '');
+};
+
 module.exports = {
   isLayoutComponent,
   isGridBasedComponent,
@@ -517,5 +521,6 @@ module.exports = {
   insertGridHeader,
   insertGridRow,
   convertToString,
-  formioComponents
+  formioComponents,
+  //cleanLabelTemplate
 };

--- a/src/util/email/utils.js
+++ b/src/util/email/utils.js
@@ -522,5 +522,5 @@ module.exports = {
   insertGridRow,
   convertToString,
   formioComponents,
-  //cleanLabelTemplate
+  cleanLabelTemplate
 };


### PR DESCRIPTION
# Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10478

## Description

**What changed?**

Emails with select component are blocked to send as this PR (https://github.com/formio/formio-monorepo/pull/211/files) was not fully cherry-picked to 4.5.x and cleanLabelTemplate was undefined. This PR adds the missing code. Master branch works ok.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
